### PR TITLE
Fix variable matching in hackney_url

### DIFF
--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -40,9 +40,9 @@ parse_url(URL, S) ->
                                            path = Path });
         [Addr, Path] ->
             RawPath =  <<"/", Path/binary>>,
-            {Path, Query, Fragment} = parse_path(Path),
+            {Path1, Query, Fragment} = parse_path(Path),
             parse_addr(Addr, S#hackney_url{raw_path = RawPath,
-                                           path = Path,
+                                           path = Path1,
                                            qs = Query,
                                            fragment = Fragment})
     end.


### PR DESCRIPTION
If the full path includes query strings or fragments, there will be errors in matching.
