### PR TITLE
fix: added back catch of 4 tuple response to transferdecode

### DIFF
--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -195,6 +195,9 @@ transfer_decode(Data, Client=#client{
         {done, Data2, Rest} ->
             Client2 = transfer_decode_done(Rest, Client),
             content_decode(ContentDecode, Data2, Client2);
+        {done, Data2, _Length, Rest} ->
+            Client2 = transfer_decode_done(Rest, Client),
+            content_decode(ContentDecode, Data2, Client2);
         done ->
             Client2 = transfer_decode_done(<<>>, Client),
             {done, Client2};


### PR DESCRIPTION
Just ran into a bug when not doing chunked responses due to my removal of a case clause in transfer_decode. Since the Length was simple ignore and I thought I had take it out of any place that returned it I thought it would be fine. I guess I missed some. For now I've just added the clause back.
