### PR TITLE
Add expm package files

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,18 @@
+Expm.Package.new(name: "hackney", description: "Simple HTTP client in Erlang",
+                 version: "0.3.0", keywords: ["http","client","binary"], 
+                 dependencies: ["mimetypes"],
+                 licenses: [[name: "Apache License, Version 2.0", file: "LICENSE"]],
+                 contributors: [[name: "Adam Rutkowski",
+                                 email: "hq@mtod.org"
+                                ],
+                                [name: "ILYA Khlopotov",
+                                 email: "ilya.khlopotov@gmail.com"
+                                ],
+                                [name: "Leo Lou",
+                                 email: "louyuhong@gmail.com"
+                                ],                                
+                               ],
+                 maintainers: [[name: "Benoit Chesneau", 
+                                email: "bchesneau@gmail.com"]],
+                 repositories: [[github: "benoitc/hackney", tag: "0.3.0"]])
+    

--- a/package.head.exs
+++ b/package.head.exs
@@ -1,0 +1,18 @@
+Expm.Package.new(name: "hackney", description: "Simple HTTP client in Erlang",
+                 version: :head, keywords: ["http","client","binary"], 
+                 dependencies: ["mimetypes"],                 
+                 licenses: [[name: "Apache License, Version 2.0", file: "LICENSE"]],
+                 contributors: [[name: "Adam Rutkowski",
+                                 email: "hq@mtod.org"
+                                ],
+                                [name: "ILYA Khlopotov",
+                                 email: "ilya.khlopotov@gmail.com"
+                                ],
+                                [name: "Leo Lou",
+                                 email: "louyuhong@gmail.com"
+                                ],                                
+                               ],
+                 maintainers: [[name: "Benoit Chesneau", 
+                                email: "bchesneau@gmail.com"]],
+                 repositories: [[github: "benoitc/hackney"]])
+    


### PR DESCRIPTION
Hi,

This pull request includes package definition files for your project for inclusion at http://expm.co, a [next generation package index](http://rashkovskii.com/2012/10/01/expm-or-meet-agner-2/) for Elixir & Erlang (and other BEAM-based languages).

I would highly appreciate if you will be able to publish them to the index (and optionally, merge this pull request, at your discretion). This is a very simple procedure:
### Download expm:

```
$ curl -o expm http://expm.co/__download__/expm 
$ chmod +x expm
```
### Publish files:

```
$ expm --username USERNAME --password PASSWORD publish
```

Also, for package.head.exs:

```
$ expm --username USERNAME --password PASSWORD publish package.head.exs
```

There's no need to create an account in order to publish your package.

Simply use username and password options when claiming new package and this username and password combination will be attached to your package on the server. No one without your username and password can update the package.

If you are not interested in maintaining records for your project, please let me know and we'll publish it to the index on your behalf.

Thanks!
