### PR TITLE
Don't stream the response body on head requests

### DIFF
--- a/include/hackney.hrl
+++ b/include/hackney.hrl
@@ -60,6 +60,7 @@
         clen = nil,
         te = nil,
         connection = nil,
+        method = nil,
         ctype = nil}).
 
 -record(hackney_url, {

--- a/src/hackney_request.erl
+++ b/src/hackney_request.erl
@@ -88,7 +88,8 @@ perform(Client0, {Method0, Path, Headers0, Body0}) ->
                     E;
                 {ok, Client2} ->
                     case end_stream_body(Client2) of
-                        {ok, FinalClient} ->
+                        {ok, Client3} ->
+                            FinalClient = Client3#client{method=Method},
                             hackney_response:start_response(FinalClient);
                         Error ->
                             Error

--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -134,12 +134,12 @@ parse_header(Line, Client) ->
     {header, {Key, Value}, Client1}.
 
 
-stream_body(Client=#client{body_state=waiting, te=TE, clen=Length}) ->
+stream_body(Client=#client{body_state=waiting, te=TE, clen=Length, method=Method}) ->
 	case TE of
 		<<"chunked">> ->
 			stream_body(Client#client{body_state=
 				{stream, fun te_chunked/2, {0, 0}, fun ce_identity/1}});
-		_ when Length =:= 0 ->
+		_ when Length =:= 0 orelse Method =:= <<"HEAD">> ->
             {done, Client#client{body_state=done}};
         _ ->
 		    stream_body(Client#client{body_state=


### PR DESCRIPTION
A HEAD request must return the same headers as a GET
request but no body. This means a Content-Length header
is actually set for such requests but no body is sent
back, leading to timeouts before this commit.
