### PR TITLE
Use byte_size/1 instead of length/1 on binary

### DIFF
--- a/src/hackney_form.erl
+++ b/src/hackney_form.erl
@@ -22,7 +22,7 @@ encode_form(KVs) ->
 encode_form([], Acc) ->
     Lines = hackney_util:join(lists:reverse(Acc), <<"&">>),
     CType = <<"application/x-www-form-urlencoded; charset=utf-8">>,
-    {erlang:length(Lines), CType, Lines};
+    {erlang:byte_size(Lines), CType, Lines};
 encode_form([{K,V}|R], Acc) ->
     K1 = hackney_url:urlencode(K),
     V1 = hackney_url:urlencode(V),


### PR DESCRIPTION
By all means it seems that hackney_util:join/2 return binary value so
length/1 is not applicable, byte_size/1 is.
