### PR TITLE
Provide a way to set connection timeout

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -162,6 +162,8 @@ request(Method, URL, Headers, Body) ->
 %%          <li>{proxy, proxy_options()}: to connect via a proxy.</li>
 %%          <li>insecure: to perform "insecure" SSL connections and
 %%          transfers without checking the certificate</li>
+%%          <li>{connect_timeout, infinity | integer()}: timeout used when
+%%          estabilishing a connection, in milliseconds. Default is 8000</li>
 %%          <li>{recv_timeout, infinity | integer()}: timeout used when
 %%          receiving a connection. Default is infinity</li>
 %%      </ul>
@@ -373,6 +375,7 @@ socket_from_pool(Pool, {Transport, Host, Port}=Key,
 
 do_connect(Transport, Host, Port, #client{options=Opts}=Client) ->
     ConnectOpts0 = proplists:get_value(connect_options, Opts, []),
+    ConnectTimeout = proplists:get_value(connect_timeout, Opts, 8000),
 
     %% handle ipv6
     ConnectOpts1 = case hackney_util:is_ipv6(Host) of
@@ -397,7 +400,7 @@ do_connect(Transport, Host, Port, #client{options=Opts}=Client) ->
             ConnectOpts1
     end,
 
-    case Transport:connect(Host, Port, ConnectOpts) of
+    case Transport:connect(Host, Port, ConnectOpts, ConnectTimeout) of
         {ok, Skt} ->
             FollowRedirect = proplists:get_value(follow_redirect,
                                                  Opts, false),

--- a/src/hackney_ssl_transport.erl
+++ b/src/hackney_ssl_transport.erl
@@ -6,7 +6,7 @@
 %%% Copyright (c) 2011-2012, Loïc Hoguin <essen@ninenines.eu>
 
 -module(hackney_ssl_transport).
--export([connect/3,
+-export([connect/3, connect/4,
          recv/3, recv/2,
          send/2,
          setopts/2,
@@ -15,9 +15,13 @@
          close/1,
          sockname/1]).
 
-connect(Host, Port, Opts) when is_list(Host), is_integer(Port) ->
+connect(Host, Port, Opts) ->
+	connect(Host, Port, Opts, infinity).
+
+connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
+	(Timeout =:= infinity orelse is_integer(Timeout)) ->
 	ssl:connect(Host, Port,
-		Opts ++ [binary, {active, false}, {packet, raw}]).
+		Opts ++ [binary, {active, false}, {packet, raw}], Timeout).
 
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).

--- a/src/hackney_tcp_transport.erl
+++ b/src/hackney_tcp_transport.erl
@@ -6,7 +6,7 @@
 %%% Copyright (c) 2011-2012, Loïc Hoguin <essen@ninenines.eu>
 %%%
 -module(hackney_tcp_transport).
--export([connect/3,
+-export([connect/3, connect/4,
          recv/2, recv/3,
          send/2,
          setopts/2,
@@ -15,9 +15,13 @@
          close/1,
          sockname/1]).
 
-connect(Host, Port, Opts) when is_list(Host), is_integer(Port) ->
+connect(Host, Port, Opts) ->
+	connect(Host, Port, Opts, infinity).
+
+connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
+	(Timeout =:= infinity orelse is_integer(Timeout)) ->
 	gen_tcp:connect(Host, Port,
-		Opts ++ [binary, {active, false}, {packet, raw}]).
+		Opts ++ [binary, {active, false}, {packet, raw}], Timeout).
 
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).


### PR DESCRIPTION
... and set a reasonable default of 8 seconds.

Since hackney client does its network related activities in the same calling process, I think it would be great to limit socket connect timeout down to some value.
