### PR TITLE
add a leading slash to #hackney_url{path}

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -193,7 +193,7 @@ request(Method, #hackney_url{}=URL, Headers, Body, Options0) ->
                  port = Port,
                  user = User,
                  password = Password,
-                 raw_path = Path} = URL,
+                 path = Path} = URL,
 
     Options = case User of
         nil ->

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -43,7 +43,7 @@ parse_url(URL, S) ->
             RawPath =  <<"/", Path/binary>>,
             {Path1, Query, Fragment} = parse_path(Path),
             parse_addr(Addr, S#hackney_url{raw_path = RawPath,
-                                           path = Path1,
+                                           path = <<"/", Path1/binary>>,
                                            qs = Query,
                                            fragment = Fragment})
     end.


### PR DESCRIPTION
It seems to be an oversight that #hackney_url{path} doesn't start with a slash, and also that hackney will send the url fragment when making a request.

Some web sites, like stackoverflow for example, will not like that request.

This patch adds a leading slash to #hackney_url{path}
and sends #hackney_url{path} instead of raw_path in the request function
