### PR TITLE
Define shortcut functions through macros

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -21,6 +21,10 @@
          body/1, body/2, skip_body/1,
          pool/1]).
 
+-define(METHOD_TPL(Method),
+        -export([Method/1, Method/2])).
+-include("methods.hrl").
+
 -include("hackney.hrl").
 
 -type url() :: #hackney_url{}.
@@ -536,3 +540,11 @@ use_default_pool() ->
         _ ->
             false
     end.
+
+-define(METHOD_TPL(Method),
+        Method(URL) -> hackney:request(Method, URL)).
+-include("methods.hrl").
+
+-define(METHOD_TPL(Method),
+        Method(URL, Headers) -> hackney:request(Method, URL, Headers)).
+-include("methods.hrl").

--- a/src/methods.hrl
+++ b/src/methods.hrl
@@ -1,0 +1,38 @@
+?METHOD_TPL(delete).
+?METHOD_TPL(get).
+?METHOD_TPL(head).
+?METHOD_TPL(post).
+?METHOD_TPL(put).
+
+%% hackney:connect/1 already exists.
+%% ?METHOD_TPL(connect).
+?METHOD_TPL(options).
+?METHOD_TPL(trace).
+
+%% WEBDAV
+?METHOD_TPL(copy).
+?METHOD_TPL(lock).
+?METHOD_TPL(mkcol).
+?METHOD_TPL(move).
+?METHOD_TPL(propfind).
+?METHOD_TPL(proppatch).
+?METHOD_TPL(search).
+?METHOD_TPL(unlock).
+
+%% SUBVERSION
+?METHOD_TPL(report).
+?METHOD_TPL(mkactivity).
+?METHOD_TPL(checkout).
+?METHOD_TPL(merge).
+
+%% UPNP
+?METHOD_TPL(msearch).
+?METHOD_TPL(notify).
+?METHOD_TPL(subscribe).
+?METHOD_TPL(unsubscribe).
+
+%% RFC-5789
+?METHOD_TPL(patch).
+?METHOD_TPL(purge).
+
+-undef(METHOD_TPL).


### PR DESCRIPTION
An include file is used, invoking the macro `?METHOD_TPL/1` with every method which should have a shortcut. This file is then included three times, first for export attributes, second for the `Method/1` shortcut and finally for the `Method/2` one.
