### PR TITLE
Start asn1 explicitly

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -6,7 +6,7 @@
   {description, "simple HTTP client"},
   {vsn, "0.4.2"},
   {registered, [hackney_pool]},
-  {applications, [kernel, stdlib, crypto, public_key, ssl]},
+  {applications, [kernel, stdlib, crypto, asn1, public_key, ssl]},
   {mod, { hackney_app, nil}},
   {env, [{timeout, 150000}, {pool_size, 50}]}
  ]}.


### PR DESCRIPTION
It appears that Erlang R16B on Ubuntu (raring, at least) doesn't automatically start the asn1 application for you when you start public_key. Same with crypto. It does on some systems, but I've got it failing to do so on two different raring machines.

As such, the fix is just to start asn1 explicitly instead of expecting it to already be started for us. See this example:

```
1> application:start(public_key).
{error,{not_started,asn1}}
2> application:start(asn1).
ok
3> application:start(public_key).
{error,{not_started,crypto}}
4> application:start(crypto).
ok
5> application:start(public_key).
ok
```
