### PR TITLE
Miscellaneous patches

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -193,7 +193,7 @@ request(Method, URL, Headers, Body) ->
 %%  <bloquote>Note: instead of doing `hackney:request(Method, ...)' you can
 %%  also do `hackney:Method(...)' if you prefer to use the REST
 %%  syntax.</bloquote>
--spec request(term(), binary(), list(), term(), list())
+-spec request(term(), url() | binary(), list(), term(), list())
     -> {ok, integer(), list(), #client{}} | {error, term()}.
 request(Method, #hackney_url{}=URL, Headers, Body, Options0) ->
     #hackney_url{transport=Transport,
@@ -361,14 +361,18 @@ maybe_proxy(Transport, Host, Port, Options)
     end.
 
 connect_proxy(ProxyUrl, Host, Port, ProxyOpts0, Options) ->
-    Host = iolist_to_binary([Host, ":", integer_to_list(Port)]),
-    Headers = [{<<"Host">>, Host}],
+    Host1 = iolist_to_binary([Host, ":", integer_to_list(Port)]),
+    Headers = [{<<"Host">>, Host1}],
     Timeout = proplists:get_value(recv_timeout, Options, infinity),
     ProxyOpts = [{recv_timeout, Timeout} | ProxyOpts0],
     case request(connect, ProxyUrl, Headers, <<>>, ProxyOpts) of
         {ok, 200, _, Client0} ->
-            Client = skip_body(Client0),
-            {ok, Client#client{recv_timeout=Timeout, options=Options}};
+            case skip_body(Client0) of
+                {ok, Client} -> 
+                    {ok, Client#client{recv_timeout=Timeout, options=Options}};
+                {error, Reason} -> 
+                    {error, {proxy_connection, Reason}}
+            end;
         {ok, S, H, Client} ->
             Body = body(Client),
             {error, {proxy_connection, S, H, Body}};

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -199,7 +199,7 @@ remove_socket(Socket, #state{connections=Conns, sockets=Sockets}=State) ->
             NewConns = update_connections(ConnSockets, Key, Conns),
             NewSockets = dict:erase(Socket, Sockets),
             State#state{connections=NewConns, sockets=NewSockets};
-        false ->
+        error ->
             State
     end.
 

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -71,6 +71,8 @@ unparse_url(#hackney_url{}=Url) ->
     Netloc1 = case User of
         <<>> ->
             Netloc;
+        nil ->
+            Netloc;
         _ when Password /= <<>>, Password /= <<"">> ->
             << User/binary, ":", Password/binary, "@", Netloc/binary >>;
         _ ->


### PR DESCRIPTION
Note that I haven't run the code - this is all straight from dialyzer's mouth.  But hey, some of these _are_ problems...

_hackney.erl_
1. correct spec to allow URL to be url() | binary()
- just making this explicit
  1. Possible typo in header generation
- in `connect_proxy`, you probably meant to generate a _new_ value for Host.  The code, as it exists, probably would have barfed.
  1. The return from skip_body is actually {ok, _}| {error _}
- `skip_body` returns {ok, #client{}} | {error, any()}.  The code, as it exists, wouldn't have worked.

_hackney_pool.erl_
1.dict:find returns error, not false
- I _know_ that needs to be fixed :-)

_hackney_url.erl_
1. Added 'nil' handling
- _Theoretically_, the code path allows a 'nil' value for User to make it through to this point
