### PR TITLE
Add missing mimetypes dependency

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -6,7 +6,7 @@
   {description, "simple HTTP client"},
   {vsn, "0.4.2"},
   {registered, [hackney_pool]},
-  {applications, [kernel, stdlib, crypto, asn1, public_key, ssl]},
+  {applications, [kernel, stdlib, crypto, asn1, public_key, ssl, mimetypes]},
   {mod, { hackney_app, nil}},
   {env, [{timeout, 150000}, {pool_size, 50}]}
  ]}.


### PR DESCRIPTION
This missing dependency will cause the mimetypes library to be left
out of a release.
