### PR TITLE
Fix proxied connections - establish correctly, don't read body.

### DIFF
--- a/src/hackney_request.erl
+++ b/src/hackney_request.erl
@@ -83,8 +83,15 @@ perform(Client0, {Method0, Path, Headers0, Body0}) ->
                     [ << K/binary, ": ", V1/binary, "\r\n" >> | Lines]
             end, [], HeaderDict1),
 
+    HostOrPath = case Method0 of
+        connect ->
+            hackney_headers:get_value(<<"host">>, HeadersDict);
+        _ ->
+            Path
+    end,
+
     HeadersData = iolist_to_binary([
-                << Method/binary, " ", Path/binary, " HTTP/1.1", "\r\n" >>,
+                << Method/binary, " ", HostOrPath/binary, " HTTP/1.1", "\r\n" >>,
                 HeadersLines,
                 <<"\r\n">>]),
 


### PR DESCRIPTION
Hi,

I found that attempting to use an HTTP proxy was failing, using this library from "Project Fifo" (http://project-fifo.net). They're currently specifying version 0.4.0 of hackney, but I found that even 0.4.4 wouldn't work through my squid proxy.

There seemed to be two problems:

We would send "CONNECT / HTTP/1.1", instead of sending the host and port, like "CONNECT host:80 HTTP/1.1", although the correct host and port were present in the Host: header. This meant that squid immediately rejected the request.

We would then attempt to read the body to EOF following a "200 Connection Established" from the proxy, rather than carrying on by sending the actual request. This meant that we would time out, and the request which should have been proxied would be sent direct on a new connection and then fail.

I believe that I've managed to fix these issues, and certainly with this patch, I'm able to use a proxy with my Fifo installation. I was also still able to run the example scripts, so I believe non-proxied connections do still work. 

Thanks!
