### PR TITLE
Removed extra trailing lf in multipart form fields

### DIFF
--- a/src/hackney_multipart.erl
+++ b/src/hackney_multipart.erl
@@ -29,7 +29,7 @@ encode_form([], Boundary, Acc) ->
     {erlang:size(Lines), CType, Lines};
 encode_form([C | R], Boundary, Acc) ->
     Field = encode(C, Boundary),
-    encode_form(R, Boundary, hackney_util:join([Acc, Field], "\r\n")).
+    encode_form(R, Boundary, iolist_to_binary([Acc, Field])).
 
 decode_form(_) -> {error, not_implemented}.
 


### PR DESCRIPTION
before patch:

```

-----------------------------mtynipxrmpegseog
Content-Disposition: form-data; name="width"
Content-Type: application/octet-stream

100

-----------------------------mtynipxrmpegseog
Content-Disposition: form-data; name="height"
Content-Type: application/octet-stream

80
-----------------------------mtynipxrmpegseog--
```

after patch:

```
-----------------------------mtynipxrmpegseog
Content-Disposition: form-data; name="width"
Content-Type: application/octet-stream

100
-----------------------------mtynipxrmpegseog
Content-Disposition: form-data; name="height"
Content-Type: application/octet-stream

80
-----------------------------mtynipxrmpegseog--
```
