### PR TITLE
Make sure that the controlling process of the socket is the pool process when the socket is in the pool

### DIFF
--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -38,6 +38,7 @@ socket(PidOrName, {Transport, Host0, Port}) ->
 %% @doc release a socket in the pool
 release(PidOrName, {Transport, Host0, Port}, Socket) ->
     Host = string:to_lower(Host0),
+    Transport:controlling_process(Socket, PidOrName),
     gen_server:call(PidOrName, {release, {Transport, Host, Port}, Socket}).
 
 %% @doc get total pool size


### PR DESCRIPTION
A process can't reuse a socket connected by another process for now because the socket is closed when the process which connected the socket to the server is dead.

The following are the result of my experiment.
- before
  `#Port<0.1680>` and `#Port<0.1681>`

``` erlang
1> hackney:start(). 
ok
2> spawn(fun() ->
2>   {_,_,_,C}=hackney:request(get, "http://localhost:8080",[{<<"Connection">>, <<"Keep-Alive">>}], <<>>, [{pool,default}]),
2>   io:format("~p~n",[C]),
2>   hackney:body(C)
2> end).
<0.59.0>
3> timer:sleep(1000)
{client,hackney_tcp_transport,"localhost",8080,netloc,
        [{pool,default}],
        #Port<0.1680>,infinity,false,5,false,nil,undefined,connected,on_body,
        nil,normal,#Fun<hackney_request.send.2>,waiting,4096,<<"abc">>,
        {1,1},
        3,nil,<<"keep-alive">>,<<"GET">>,nil}
3> hackney:request(get, "http://localhost:8080",[{<<"Connection">>, <<"Keep-Alive">>}], <<>>, [{pool,default}]).
{ok,200,
    [{<<"connection">>,<<"keep-alive">>},
     {<<"server">>,<<"Cowboy">>},
     {<<"date">>,<<"Thu, 17 Oct 2013 01:47:02 GMT">>},
     {<<"content-length">>,<<"3">>}],
    {client,hackney_tcp_transport,"localhost",8080,netloc,
            [{pool,default}],
            #Port<0.1681>,infinity,false,5,false,nil,undefined,
            connected,on_body,nil,normal,#Fun<hackney_request.send.2>,
            waiting,4096,<<"abc">>,
            {1,1},
            3,nil,<<...>>,...}}
```
- after

`#Port<0.1680>` and `#Port<0.1680>`

``` erlang
1> hackney:start(). 
ok
2> spawn(fun() ->
2>   {_,_,_,C}=hackney:request(get, "http://localhost:8080",[{<<"Connection">>, <<"Keep-Alive">>}], <<>>, [{pool,default}]),
2>   io:format("~p~n",[C]),
2>   hackney:body(C)
2> end).
<0.59.0>
3> timer:sleep(1000),
{client,hackney_tcp_transport,"localhost",8080,netloc,
        [{pool,default}],
        #Port<0.1680>,infinity,false,5,false,nil,undefined,connected,on_body,
        nil,normal,#Fun<hackney_request.send.2>,waiting,4096,<<"abc">>,
        {1,1},
        3,nil,<<"keep-alive">>,<<"GET">>,nil}
3> hackney:request(get, "http://localhost:8080",[{<<"Connection">>, <<"Keep-Alive">>}], <<>>, [{pool,default}]).
{ok,200,
    [{<<"connection">>,<<"keep-alive">>},
     {<<"server">>,<<"Cowboy">>},
     {<<"date">>,<<"Thu, 17 Oct 2013 01:50:10 GMT">>},
     {<<"content-length">>,<<"3">>}],
    {client,hackney_tcp_transport,"localhost",8080,netloc,
            [{pool,default}],
            #Port<0.1680>,infinity,false,5,false,nil,undefined,
            connected,on_body,nil,normal,#Fun<hackney_request.send.2>,
            waiting,4096,<<"abc">>,
            {1,1},
            3,nil,<<...>>,...}}
```
