### PR TITLE
Slightly optimize hackney_util:join/3

### DIFF
--- a/src/hackney_util.erl
+++ b/src/hackney_util.erl
@@ -130,7 +130,7 @@ join([], _Separator, Acc) ->
 join([S | Rest], Separator, []) ->
     join(Rest, Separator, [S]);
 join([S | Rest], Separator, Acc) ->
-    join(Rest, Separator, [S, Separator, Acc]).
+    join(Rest, Separator, [S, Separator | Acc]).
 
 to_hex([]) ->
     [];


### PR DESCRIPTION
`hackney_util:join/3` was creating an `iolist()` with unneeded levels of nests.
