### PR TITLE
allow user to differentiate connect/recv timeout

### DIFF
--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -238,6 +238,8 @@ do_connect(Host, Port, Transport, #client{options=Opts,
                     Client1#client{request_ref=Ref}
             end,
             {ok, FinalClient};
+        {error, timeout} ->
+            {error, connect_timeout};
         Error ->
             Error
     end.


### PR DESCRIPTION
when we get an {error, timeout} during gen_tcp:connect return {error, connect_timeout} instead of {error, timeout}

previously you would get {error, timeout} both when a gen_tcp:connect timed out and when a receive timeout was reached.

this kind of breaks the API a bit but I think it is an improvement. you may want to look at further changes that make it easier for clients to separate errors where the request definitely did not reach the server from errors where the request may have reached the server. having an {error, {connection_failed, Reason}} might be better. i think ibrowse does something like this.
