### PR TITLE
fix hackney_manager child spec: supervisor -> worker

### DIFF
--- a/src/hackney_sup.erl
+++ b/src/hackney_sup.erl
@@ -33,6 +33,6 @@ init([]) ->
     %% init the table to find a pool
     ets:new(hackney_pool, [named_table, set, public]),
 
-    Manager= ?CHILD(hackney_manager, supervisor),
+    Manager = ?CHILD(hackney_manager, worker),
 
     {ok, { {one_for_one, 10, 1}, [Manager]}}.


### PR DESCRIPTION
Hackney manager is a worker not a supervisor

Noticed when I tried to use hackney as dep in a proper erlang release, and it fails because supervisors are interrogated with which_children calls.
