### PR TITLE
Make hackney_pool ets from hackney_manager

### DIFF
--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -156,9 +156,19 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 init(_) ->
+    ets:new(hackney_pool, [
+                    named_table,
+                    set,
+                    public
+            ]),
+    ets:new(?MODULE, [
+                    set,
+                    {keypos, 1},
+                    public,
+                    named_table,
+                    {write_concurrency, true}
+            ]),
     process_flag(trap_exit, true),
-    ets:new(?MODULE, [set, {keypos, 1}, public, named_table,
-                      {write_concurrency, true}]),
     {ok, dict:new()}.
 
 

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -45,6 +45,8 @@
 
 
 start() ->
+    %% NB this is first called from hackney_sup:start_link
+    %%    BEFORE the hackney_pool ETS table exists
     ok.
 
 %% @doc fetch a socket from the pool

--- a/src/hackney_sup.erl
+++ b/src/hackney_sup.erl
@@ -30,8 +30,6 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-    %% init the table to find a pool
-    ets:new(hackney_pool, [named_table, set, public]),
 
     Manager= ?CHILD(hackney_manager, supervisor),
 


### PR DESCRIPTION
Making it from the supervisor is unnecessary. Trying to create a new named
ets table that already exists will crash, like when supervisor:init is called
again during release upgrades, to check if the child specs have changed.
