### PR TITLE
Don't overwrite the `Host` header if passed in

### DIFF
--- a/src/hackney_client/hackney.erl
+++ b/src/hackney_client/hackney.erl
@@ -541,8 +541,7 @@ stop_async(Ref) ->
 host_header(#hackney_url{netloc=Netloc}, Headers) ->
     case proplists:get_value(<<"Host">>, Headers) of
         undefined -> Headers ++ [{<<"Host">>, Netloc}];
-        _ -> lists:keyreplace(<<"Host">>, 1, Headers,
-                              {<<"Host">>, Netloc})
+        _ -> Headers
     end.
 
 make_request(connect, #hackney_url{}=URL, Headers, Body, _, _) ->


### PR DESCRIPTION
Hackney [recently](https://github.com/benoitc/hackney/commit/9b246c1445f310457cbf199dac80c9966b05c16e) started making sure that the `Host` header is always set when making a request. This is the correct behaviour according to the [`HTTP/1.1`](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23) spec.

The bug introduced with this feature is that user-supplied `Host` headers are overwritten by Hackney with the host extracted from the URI. This isn't always what the user wants to do, for example in test cases.

This commit checks for the `Host` header and adds it if it is missing. If one is already present the header will not be replaced and the user-supplied `Host` header will be used.
