### PR TITLE
Try to run HTTP tests using httpbin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ otp_release:
   - R15B02
   - R15B01
   - R15B
+before_install:
+  - sudo pip install -q httpbin
+  - sudo pip install -q gunicorn
+before_script: gunicorn httpbin:app&

--- a/README.md
+++ b/README.md
@@ -60,7 +60,20 @@ repository](http://github.com/benoitc/hackney)
 To build the application simply run 'make'. This should build .beam, .app
 files and documentation.
 
-To run tests run 'make test'.
+To run tests you need to install `gunicorn` and `httpbin` python packages:
+
+```
+pip install gunicorn httpbin
+```
+
+Run httpbin
+
+```
+gunicorn httpbin:app
+```
+
+Then run 'make test'.
+
 To generate doc, run 'make doc'.
 
 Or add it to your rebar config

--- a/test/hackney_integration_tests.erl
+++ b/test/hackney_integration_tests.erl
@@ -1,0 +1,34 @@
+-module(hackney_integration_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include("hackney_lib.hrl").
+
+http_requests_test_() ->
+  {setup,
+   fun start/0,
+   fun stop/1,
+   fun(SetupData) ->
+     [get_request(SetupData),
+      basic_auth_request_failed(SetupData),
+      basic_auth_request(SetupData)]
+   end}.
+
+start() -> hackney:start().
+
+stop(_) -> ok.
+
+get_request(_) ->
+  URL = <<"http://localhost:8000/get">>,
+  {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, []),
+  ?_assertEqual(StatusCode, 200).
+
+basic_auth_request(_) ->
+  URL = <<"http://localhost:8000/basic-auth/username/password">>,
+  Options = [{basic_auth, {<<"username">>, <<"password">>}}],
+  {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, Options),
+  ?_assertEqual(StatusCode, 200).
+
+basic_auth_request_failed(_) ->
+  URL = <<"http://localhost:8000/basic-auth/username/password">>,
+  Options = [{basic_auth, {<<"wrong">>, <<"auth">>}}],
+  {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, Options),
+  ?_assertEqual(StatusCode, 401).


### PR DESCRIPTION
This is a proposal for integration tests to hackney. 

The only bad thing is that you will need `httpbin` and `gunicorn` installed and running. 

If you find this is useful I can add more tests (streamed body, request using other methods, async, sendfile, etc).
