### PR TITLE
Fix hackney url tests on Erlang 17.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: erlang
 otp_release:
+  - 17.0
+  - 17.1
   - R16B02
   - R16B01
   - R16B

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -1,3 +1,4 @@
+% coding: latin-1
 -module(hackney_url_tests).
 -include_lib("eunit/include/eunit.hrl").
 -include("hackney_lib.hrl").


### PR DESCRIPTION
I don't know if this is the best solution, but setting the encoding to latin-1 on `hackney_url_tests` fixed the build on Erlang 17.\* I tried to change the file to use just UTF-8, but I failed miserably.
