### PR TITLE
Fix some typos in overview.edoc

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -42,7 +42,7 @@ Main features:
 - Optional socket pool
 - REST syntax: `hackney:Method(URL)' (where a method can be get, post, put, delete, ...)
 
-Hackney use [hackney_lib](http://github.com/benoitc/hackney_lib) to
+Hackney uses [hackney_lib](http://github.com/benoitc/hackney_lib) to
 handle any web protocols. If you want to manipulate headers, cookies,
 multipart or any other thing related to web protocols this is the place
 to go.
@@ -50,7 +50,7 @@ to go.
 
 > Note: This is a work in progress, see the
 [TODO](http://github.com/benoitc/hackney/blob/master/TODO.md) for more
-informations on what still need to be done.
+information on what still needs to be done.
 
 
 #### Useful modules are:
@@ -58,16 +58,16 @@ informations on what still need to be done.
 - {@link hackney}: main module. It contains all HTTP client functions.
 - {@link hackney_http}: HTTP parser in pure Erlang. This parser is able
   to parse HTTP responses and requests in a streaming fashion. If not set
-it will be autodetect if it's a request or a response if needed.
+it will be autodetected if it's a request or a response that's needed.
 
-- {@link hackney_headers} Module to manipulate HTTP headers
+- {@link hackney_headers} Module to manipulate HTTP headers.
 - {@link hackney_cookie}: Module to manipulate cookies.
 - {@link hackney_multipart}: Module to encode/decode multipart.
 - {@link hackney_url}: Module to parse and create URIs.
 - {@link hackney_date}: Module to parse HTTP dates.
 
 Read the [NEWS](https://raw.github.com/benoitc/hackney/master/NEWS.md) file
-to get last changelog.
+to get the last changelog.
 
 
 ## Installation
@@ -133,7 +133,7 @@ Options = [],
                                                         Headers, Payload,
                                                         Options).</pre>
 
-The request method return the tuple `{ok, StatusCode, Headers, ClientRef}'
+The request method returns the tuple `{ok, StatusCode, Headers, ClientRef}'
 or `{error, Reason}'. A `ClientRef' is simply a reference to the current
 request that you can reuse.
 
@@ -142,7 +142,7 @@ If you prefer the REST syntax, you can also do:
 
 <pre lang="erlang">hackney:Method(URL, Headers, Payload, Options)</pre>
 
-where `Method', can be any HTTP methods in lowercase.
+where `Method', can be any HTTP method in lowercase.
 
 
 ### Read the body
@@ -170,8 +170,8 @@ read_body(MaxLength, Ref, Acc) when MaxLength > byte_size(Acc) ->
 
 By default all connections are created and closed dynamically by
 hackney but sometimes you may want to reuse the same reference for your
-connections. It's especially usefull you just want to handle serially a
-couple of request.
+connections. It's especially useful if you just want to handle serially a
+couple of requests.
 
 > A closed connection will automatically be reconnected.
 
@@ -266,7 +266,7 @@ ok  = hackney:send_body(ClientRef, ReqBody),
 ### Get a response asynchronously
 
 Since the 0.6 version, hackney is able to fetch the response
-asynchrnously using the `async' option:
+asynchronously using the `async' option:
 
 <pre lang="erlang">
 Url = &lt;&lt;"https://friendpaste.com/_all_languages">>,
@@ -302,7 +302,7 @@ LoopFun(LoopFun, ClientRef).</pre>
 
 > **Note 2**:  Asynchronous responses automatically checkout the socket at the end.
 
-> **Note 3**:  At any time you can go back and received your response
+> **Note 3**:  At any time you can go back and receive your response
 > synchronously using the function `hackney:stop_async/1' See the
 > example [test_async_once2](https://github.com/benoitc/hackney/blob/master/examples/test_async_once2.erl) for the usage.
 
@@ -361,7 +361,7 @@ To close a pool do:
 Since the version 0.8 it is now possible to use your own Pool to
 maintain the connections in hackney.
 
-A pool handler is a module that handle the `hackney_pool_handler`
+A pool handler is a module that handles the `hackney_pool_handler`
 behaviour.
 
 See for example the
@@ -380,7 +380,7 @@ retrieve the body. The maximum number of connections can be set using the
 
 The client will follow redirects on 301, 302 &amp; 307 if the method is
 get or head. If another method is used the tuple
-`{ok, maybe_redirect, Status, Headers, Client}' will be returned. It
+`{ok, maybe_redirect, Status, Headers, Client}' will be returned. It will
 only follow 303 redirects (see other) if the method is a POST.
 
 Last Location is stored in the `location' property of the client state.


### PR DESCRIPTION
Hi, this just fixes some typos in the overview.edoc file. I haven't rebuilt the README.md file or anything else. :)
