### PR TITLE
Fix callback support for R14

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,11 @@
 %% ex: ft=erlang ts=4 sw=4 et
 
 %%{erl_first_files, ["hackney_pool_handler"]}.
-{erl_opts, [debug_info]}.
+{erl_opts, [
+  debug_info,
+  {platform_define, "R14", no_callback_support}
+]}.
+
 {xref_checks, [undefined_function_calls]}.
 
 {cover_enabled, true}.
@@ -16,4 +20,4 @@
           {tag, "1.0.1"}}}
 ]}.
 
-{require_otp_vsn, "R15|R16|17"}.
+{require_otp_vsn, "R14|R15|R16|17"}.

--- a/rebar_dev.config
+++ b/rebar_dev.config
@@ -2,7 +2,10 @@
 %% ex: ft=erlang ts=4 sw=4 et
 
 {erl_first_files, ["hackney_pool_handler"]}.
-{erl_opts, [debug_info]}.
+{erl_opts, [
+  debug_info,
+  {platform_define, "R14", no_callback_support}
+]}.
 {xref_checks, [undefined_function_calls]}.
 
 {cover_enabled, true}.
@@ -31,4 +34,4 @@
              {top_level_readme,
               {"./README.md", "http://github.com/benoitc/hackney"}}]}.
 
-{require_otp_vsn, "R15|R16|17"}.
+{require_otp_vsn, "R14|R15|R16|17"}.

--- a/src/hackney_connect/hackney_pool_handler.erl
+++ b/src/hackney_connect/hackney_pool_handler.erl
@@ -12,9 +12,22 @@
 -type host() :: binary() | string().
 -type client() :: #client{}.
 
+-ifdef(no_callback_support).
+
+-export([behaviour_info/1]).
+
+-spec behaviour_info(atom()) -> [{atom(), arity()}] | undefined.
+behaviour_info(callbacks) ->
+    [{start, 0},
+     {checkout, 4},
+     {checkin, 2}];
+behaviour_info(_) ->
+    undefined.
+
+-else.
+
 %% start a bool handler
 -callback start() -> ok | {error, Reason :: any()}.
-
 
 -callback checkout(Host::host(), Port::integer(),Transport::atom(),
                    Client::client()) ->
@@ -26,3 +39,5 @@
                    Transport::atom()}, Socket::inet:socket()) ->
     ok
     | {error, Reason :: any()}.
+
+-endif.


### PR DESCRIPTION
This fixes erica build against R14 (which claims to support R14 but it couldn't due to hackney) and also doesn't drops popular Erlang release branch due to one single feature.
