### PR TITLE
CT params are case sensitive, remove to_lower

### DIFF
--- a/src/hackney_client/hackney_response.erl
+++ b/src/hackney_client/hackney_response.erl
@@ -108,7 +108,7 @@ wait_headers({header, {Key, Value}=KV, Parser}, Client, Status, Headers) ->
         <<"connection">> ->
             Client#client{connection=hackney_bstr:to_lower(Value)};
         <<"content-type">> ->
-            Client#client{ctype=hackney_bstr:to_lower(Value)};
+            Client#client{ctype=Value};
         <<"location">> ->
             Client#client{location=Value};
         _ ->


### PR DESCRIPTION
According to http://www.w3.org/Protocols/rfc1341/4_Content-Type.html,
"The type, subtype, and parameter names are not case sensitive. For
example, TEXT, Text, and TeXt are all equivalent. Parameter values are
normally case sensitive"

It is very important to make multipart parser works since multipart
boundary are often with uppercase characters. Currently this makes
 the multipart parser fail most of the time.

It is OK to just remove the to_lower, since hackney_headers:content_type
uses hackney_bstr:token_ci (case insensitive) to parse the type and
subtype returning the wanted type and subtype as lowercase and params
with case.