### PR TITLE
Stop including an unused file.

### DIFF
--- a/src/hackney_connect/hackney_http_connect.erl
+++ b/src/hackney_connect/hackney_http_connect.erl
@@ -8,8 +8,6 @@
 %%%
 -module(hackney_http_connect).
 
--include_lib("kernel/src/inet_dns.hrl").
-
 -export([messages/1,
          connect/3, connect/4,
          recv/2, recv/3,

--- a/src/hackney_connect/hackney_socks5.erl
+++ b/src/hackney_connect/hackney_socks5.erl
@@ -8,8 +8,6 @@
 
 -module(hackney_socks5).
 
--include_lib("kernel/src/inet_dns.hrl").
-
 -export([messages/1,
          connect/3, connect/4,
          recv/2, recv/3,


### PR DESCRIPTION
The removal of inclusion of this file saves us dependency on erlang-src.