### PR TITLE
removing extra CRLF at the start of buffer before passing it to `parse_headers`

### DIFF
--- a/src/hackney_lib/hackney_http.erl
+++ b/src/hackney_lib/hackney_http.erl
@@ -247,7 +247,7 @@ parse_uri_path(<< C, Rest/bits >>, St, Method, Acc) ->
         _ -> parse_uri_path(Rest, St, Method, << Acc/binary, C >>)
     end.
 
-parse_version(<< "HTTP/", High, ".", Low, Rest/binary >>, St, Method, URI)
+parse_version(<< "HTTP/", High, ".", Low, $\r , $\n, Rest/binary >>, St, Method, URI)
         when High >= $0, High =< $9, Low >= $0, Low =< $9 ->
     Version = { High -$0, Low - $0},
 


### PR DESCRIPTION
a `<<"\r\b">>` at the beginning of the buffer passed to `parse_headers/1` prevented parser from correctly parsing headers. It is correctly deleted when handling responses. (see line 194 of `src/hackney_lib/hackney_http.erl`)