### PR TITLE
Fixed status line parsing when reason phrase is missing entirely.

### DIFF
--- a/src/hackney_lib/hackney_http.erl
+++ b/src/hackney_lib/hackney_http.erl
@@ -206,6 +206,8 @@ parse_response_version(<< "HTTP/", High, ".", Low, $\s, Rest/binary >>, St)
 parse_response_version(_, _) ->
      {error, bad_request}.
 
+parse_status(<<>>, St, Version, Acc) ->
+    parse_reason(<<>>, St, Version, Acc);
 parse_status(<< C, Rest/bits >>, St, Version, Acc) ->
     case C of
         $\r ->  {error, bad_request};

--- a/test/hackney_http_tests.erl
+++ b/test/hackney_http_tests.erl
@@ -15,3 +15,10 @@ parse_response_incomplete_200_test() ->
 	{response, _Version, StatusInt, Reason, _NState} =  hackney_http:parse_response_version(Response, St),
 	?assertEqual(StatusInt, 200),
 	?assertEqual(Reason, <<"">>).
+
+parse_response_missing_reason_phrase_test() ->
+    	Response = <<"HTTP/1.1 200">>,
+	St = #hparser{},
+	{response, _Version, StatusInt, Reason, _NState} =  hackney_http:parse_response_version(Response, St),
+	?assertEqual(StatusInt, 200),
+	?assertEqual(Reason, <<"">>).


### PR DESCRIPTION
Status line parsing crashes if the reason phrase is missing. This can be tested with the following request to http://mediafire.com.

```erlang
hackney:request(head, <<"http://mediafire.com/">>, [], <<"">>, []).
** exception error: no function clause matching hackney_http:parse_status(<<>>,
                                                                          {hparser,response,4096,10,0,on_first_line,
                                                                                   <<"Date: Sun, 31 May 2015 16:54:47 GMT\r\nContent-Type: text/html; charset=utf-8\r\nCon"...>>,
                                                                                   undefined,undefined,[],undefined,undefined,undefined,
                                                                                   undefined,undefined,waiting},
                                                                          {1,1},
                                                                          <<"301">>) (src/hackney_lib/hackney_http.erl, line 209)
     in function  hackney_response:wait_status/1 (src/hackney_client/hackney_response.erl, line 74)
     in call from hackney:send_request/2 (src/hackney_client/hackney.erl, line 357)
```

This pull request contains a proposed fix as well as a test to test this particular case.