### PR TITLE
Use erlang:byte_size/1 for size of binaries

### DIFF
--- a/src/hackney_client/hackney_request.erl
+++ b/src/hackney_client/hackney_request.erl
@@ -341,7 +341,7 @@ handle_body(Headers, ReqType0, Body0, Client) ->
                                            <<"application/octet-stream">>),
             {S, CT, iolist_to_binary(Body1)};
         _ when is_binary(Body0) ->
-            S = erlang:size(Body0),
+            S = erlang:byte_size(Body0),
             CT = hackney_headers:get_value(<<"content-type">>, Headers,
                                            <<"application/octet-stream">>),
             {S, CT, Body0}

--- a/src/hackney_client/hackney_request.erl
+++ b/src/hackney_client/hackney_request.erl
@@ -336,10 +336,10 @@ handle_body(Headers, ReqType0, Body0, Client) ->
 
         _ when is_list(Body0) -> % iolist case
             Body1 = iolist_to_binary(Body0),
-            S = size(Body1),
+            S = erlang:byte_size(Body1),
             CT = hackney_headers:get_value(<<"content-type">>, Headers,
                                            <<"application/octet-stream">>),
-            {S, CT, iolist_to_binary(Body1)};
+            {S, CT, Body1};
         _ when is_binary(Body0) ->
             S = erlang:byte_size(Body0),
             CT = hackney_headers:get_value(<<"content-type">>, Headers,


### PR DESCRIPTION
Not a bug but we only need the size of binaries, not binaries and tuples.  Also removed a redundant call to `iolist_to_binary`