### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ couple of requests.
 
 ```erlang
 
-Transport = hackney_tcp_transport,
-Host = << "https://friendpaste.com" >>,
+Transport = hackney_ssl_transport,
+Host = << "friendpaste.com" >>,
 Port = 443,
 Options = [],
 {ok, ConnRef} = hackney:connect(Transport, Host, Port, Options)


### PR DESCRIPTION
Host on hackney:connect should not include protocol (given by the transport). If you put the protocol in, you get `{error, nxdomain}` back from gen_tcp:connect().  Also for an SSL request, `hackney_ssl_transport` is the Transport. see: [{hackney_ssl_transport, 443} and {hackney_tcp_transport, 80}](https://github.com/benoitc/hackney/blob/master/src/hackney_connect/hackney_connect.erl#L52-L53)