### PR TITLE
Export hackney_connect:ssl_opts/2

### DIFF
--- a/src/hackney_connect/hackney_connect.erl
+++ b/src/hackney_connect/hackney_connect.erl
@@ -10,6 +10,7 @@
          maybe_connect/1,
          reconnect/4,
          set_sockopts/2,
+         ssl_opts/2,
          check_or_close/1,
          close/1,
          is_pool/1]).


### PR DESCRIPTION
Export hackney_connect:ssl_opts/2 to fix #211 issues:
```
Warning: hackney_http_connect:connect/4 calls undefined function hackney_connect:ssl_opts/2 (Xref)
Warning: hackney_socks5:connect/4 calls undefined function hackney_connect:ssl_opts/2 (Xref)
```