### PR TITLE
Fix redirection with enabled 'with_body' option

### DIFF
--- a/src/hackney_client/hackney.erl
+++ b/src/hackney_client/hackney.erl
@@ -848,14 +848,14 @@ redirect(Client0, {Method, NewLocation, Headers, Body}) ->
                                          options=Opts0}
             end,
             {ok, S, H, RedirectState1};
-        {ok,  S, H, RedirectClient} when Redirect /= nil ->
+        {ok,  S, H, #client{}=RedirectClient} when Redirect /= nil ->
             NewClient = RedirectClient#client{redirect=Redirect,
                                               follow_redirect=FollowRedirect,
                                               max_redirect=MaxRedirect,
                                               retries=Tries,
                                               options=Opts0},
             {ok, S, H, NewClient};
-        {ok, S, H, RedirectClient} ->
+        {ok, S, H, #client{}=RedirectClient} ->
             NewRedirect = {Transport, Host, Port, Opts0},
             NewClient = RedirectClient#client{redirect=NewRedirect,
                                               follow_redirect=FollowRedirect,
@@ -863,8 +863,8 @@ redirect(Client0, {Method, NewLocation, Headers, Body}) ->
                                               retries=Tries,
                                               options=Opts0},
             {ok, S, H, NewClient};
-        Error ->
-            Error
+        Response ->
+            Response
     end.
 
 redirect_location(Headers) ->


### PR DESCRIPTION
It fixes this problem:
```
hackney:request(get, <<"http://rdrct.herokuapp.com/1">>, [], [], [{follow_redirect, true}, {with_body, true}]).
** exception error: {badrecord,client}
     in function  hackney:redirect/2 (src/hackney_client/hackney.erl, line 864)
     in call from hackney:maybe_redirect1/3 (src/hackney_client/hackney.erl, line 761)
     in call from hackney:send_request/2 (src/hackney_client/hackney.erl, line 367)
     in call from hackney:redirect/2 (src/hackney_client/hackney.erl, line 832)
     in call from hackney:maybe_redirect1/3 (src/hackney_client/hackney.erl, line 761)
     in call from hackney:send_request/2 (src/hackney_client/hackney.erl, line 367)
```
I also changed 
```
Error -> Error
```
case to
```
Response -> Response
```
because it looks more correct.