### PR TITLE
close half-closed socket to avoid leak

### DIFF
--- a/src/hackney_connect/hackney_pool.erl
+++ b/src/hackney_connect/hackney_pool.erl
@@ -279,8 +279,10 @@ handle_call({checkin, Ref, Dest, Socket, Transport}, From, State) ->
                  {ok, {_Adress, _Port}} ->
                      %% socket is not closed, try to deliver it or store it
                      deliver_socket(Socket, Dest, State#state{clients=Clients2});
-                 _Error ->
-                     %% socket is probably closed just return
+                 Error ->
+                     %% socket may be half-closed, close it and return
+                     catch Transport:close(Socket),
+                     ?report_trace("checkin: socket is not ok~n", [{socket, Socket}, {peername, Error}]),
                      State#state{clients=Clients2}
              end,
     update_usage(State2),


### PR DESCRIPTION
fix #230

`inet:peername/1` returns `{error, enotconnect}` against half-closed sockets.  so they should be closed here.
we make millions of http requests per minute and get few socket leak. It is very rare case and hard to reproduce. 
but when someone checkin a socket to the pool, e.g. it means " I release the ownership of it. I will never read, write and CLOSE it." , so it is sane for hackney_pool to close the half-closed socket here. 