### PR TITLE
fix default name value of mp file header

### DIFF
--- a/src/http/hackney_multipart.erl
+++ b/src/http/hackney_multipart.erl
@@ -226,7 +226,7 @@ mp_file_header({file, Path}, Boundary) ->
 mp_file_header({file, Path, ExtraHeaders}, Boundary) ->
     FName = hackney_bstr:to_binary(filename:basename(Path)),
     Disposition = {<<"form-data">>,
-                   [{<<"name">>, <<"file">>},
+                   [{<<"name">>, <<"\"file\"">>},
                     {<<"filename">>, <<"\"", FName/binary, "\"">>}]},
     mp_file_header({file, Path, Disposition, ExtraHeaders}, Boundary);
 mp_file_header({file, Path, {Disposition, Params}, ExtraHeaders}, Boundary) ->


### PR DESCRIPTION
Is this a bug?

http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2