### PR TITLE
Add .PHONY to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,5 @@ devbuild:
 
 dialyzer:
 	$(REBAR) dialyzer
+
+.PHONY: test


### PR DESCRIPTION
`make` will only run if there isn't a
file or directory with the same name in the current
working directory. This adds .PHONY to the Makefile
so we can run `make test`.