### PR TITLE
Use cowboy to test multipart/form-data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ otp_release:
   - R16B02
   - R16B01
   - R16B
-  - R15B03
-  - R15B02
-  - R15B01
-  - R15B
 before_install:
   - sudo pip install -q httpbin
   - sudo pip install -q gunicorn

--- a/rebar.config
+++ b/rebar.config
@@ -34,5 +34,9 @@
                            {packages, false},
                            {subpackages, true},
                            {top_level_readme,
-                            {"./README.md", "http://github.com/benoitc/hackney"}}]}
-             ]}]}.
+                            {"./README.md", "http://github.com/benoitc/hackney"}}]}]},
+             {test, [
+               {deps, [
+                  {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "1.0.4"}}}
+               ]} ]}
+           ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -21,7 +21,8 @@ Rebar2Deps = [{idna, ".*",
 
               {ssl_verify_hostname, ".*",
                {git, "https://github.com/deadtrickster/ssl_verify_hostname.erl",
-                {tag, "1.0.5"}}}],
+                {tag, "1.0.5"}}},
+              {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {tag, "1.0.4"}}}],
 
 case IsRebar3 of
     true ->

--- a/src/http/hackney_multipart.erl
+++ b/src/http/hackney_multipart.erl
@@ -135,7 +135,7 @@ mp_header(Headers, Boundary) ->
 
 %% @doc return the boundary ennding a multipart
 mp_eof(Boundary) ->
-    <<"--",  Boundary/binary, "--">>.
+    <<"--",  Boundary/binary, "--\r\n">>.
 
 %% @doc create a part
 part(Content, Headers, Boundary) ->

--- a/test/hackney_integration_tests.erl
+++ b/test/hackney_integration_tests.erl
@@ -25,7 +25,9 @@ http_requests_test_() ->
                        async_no_content_request()]}
      end}.
 
-start() -> hackney:start().
+start() ->
+    hackney:start(),
+    ok.
 
 stop(ok) -> ok.
 

--- a/test/hackney_multipart_tests.erl
+++ b/test/hackney_multipart_tests.erl
@@ -1,0 +1,46 @@
+-module(hackney_multipart_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include("hackney_lib.hrl").
+
+%% This seems necessary to list the tests including the generator
+dummy_test() ->
+    ?assertEqual(ok, ok).
+
+multipart_test_() ->
+    {setup, fun start/0, fun stop/1,
+      [multipart_post()]}.
+      
+start() ->
+    error_logger:tty(false),
+    application:start(ranch),
+    application:start(cowlib),
+    application:start(cowboy),
+    hackney:start(),
+    Host = '_',
+    Resource = {"/mp", upload_resource, []},
+    Dispatch = cowboy_router:compile([{Host, [Resource]}]),
+    cowboy:start_http(test_server, 10, [{port, 8123}], [{env, [{dispatch, Dispatch}]}]).
+
+stop({ok, _Pid}) ->
+    cowboy:stop_listener(test_server),
+    application:stop(cowboy),
+    application:stop(hackney),
+    error_logger:tty(true),
+    ok.
+
+multipart_post() ->
+    fun() ->
+        URL = <<"http://localhost:8123/mp">>,
+        Headers = [],
+        Parts = [
+            {<<"part1">>, <<"foo">>},
+            {<<"part2">>, <<"bar">>},
+            {<<"part3">>, <<"baz">>}],
+        case hackney:request(post, URL, Headers, {multipart, Parts}, []) of
+            {ok, Code, _Headers, Ref} when code >= 200, Code < 300 ->
+                {ok, Body} = hackney:body(Ref),
+                hackney:close(Ref),
+                ?assertEqual(Parts, binary_to_term(Body))
+        end
+    end.
+

--- a/test/upload_resource.erl
+++ b/test/upload_resource.erl
@@ -1,0 +1,33 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @doc Upload handler.
+-module(upload_resource).
+
+-export([init/3]).
+-export([handle/2]).
+-export([terminate/3]).
+
+init(_, Req, _Opts) ->
+	{ok, Req, undefined}.
+
+handle(Req, State) ->
+    {Terms, Req2} = from_multipart(Req, []),
+    Bin = term_to_binary(Terms),
+    {ok, Req3} = cowboy_req:reply(200, [{<<"Content-Type">>, <<"application/x-erlang-term">>}], Bin, Req2),
+    {ok, Req3, State}.
+
+terminate(_Reason, _Req, _State) ->
+    ok.
+
+from_multipart(Req, Bodies) ->
+    case cowboy_req:part(Req) of
+        {ok, Headers, Req2} ->
+            {Req4, N, B} = case cow_multipart:form_data(Headers) of
+              {data, FieldName} ->
+                  {ok, Body, Req3} = cowboy_req:part_body(Req2),
+                  {Req3, FieldName, Body}
+            end,
+            from_multipart(Req4, [{N, B} | Bodies]);
+        {done, Req2} ->
+            {lists:reverse(Bodies), Req2}
+    end.


### PR DESCRIPTION
This PR introduces a small test case for the multipart upload. Currently it fails with a 500 error inside cowboy because hackney is doing things which is against the RFC. The PR is part of fixing #197 since it provides the counter-example for the current operation.

I envision we can take this PR and a fix together so we can avoid regressions on this area later on.