### PR TITLE
Use rebar2 dependency definitions in mix

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -4,7 +4,7 @@ IsRebar3 = case application:get_key(rebar, vsn) of
                    [Maj, Min, Patch] = string:tokens(VSN1, "."),
                    (list_to_integer(Maj) >= 3);
                undefined ->
-                   lists:keymember(mix, 1, application:loaded_applications())
+                   false
            end,
 
 Rebar2Deps0 = [{idna, ".*",


### PR DESCRIPTION
Mix doesn't yet support rebar3 dependency definitions, so we should use the rebar2 dependencies until mix adds support.