### PR TITLE
fix(hackney_url): pass "@" unescaped

### DIFF
--- a/src/http/hackney_url.erl
+++ b/src/http/hackney_url.erl
@@ -368,7 +368,7 @@ partial_pathencode(<<C, Rest/binary>> = Bin, Acc) ->
     if	C >= $0, C =< $9 -> partial_pathencode(Rest, <<Acc/binary, C>>);
         C >= $A, C =< $Z -> partial_pathencode(Rest, <<Acc/binary, C>>);
         C >= $a, C =< $z -> partial_pathencode(Rest, <<Acc/binary, C>>);
-        C =:= $;; C =:= $=; C =:= $,; C =:= $: ->
+        C =:= $;; C =:= $=; C =:= $,; C =:= $:; C =:= $@ ->
             partial_pathencode(Rest, <<Acc/binary, C>>);
         C =:= $.; C =:= $-; C =:= $+; C =:= $~; C =:= $_ ->
             partial_pathencode(Rest, <<Acc/binary, C>>);

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -259,7 +259,8 @@ pathencode_test_() ->
             {<<"/path1/path2%2fa">>, <<"/path1/path2%2fa">>},
             {<<"/path1/path2%2fa%2fb">>, <<"/path1/path2%2fa%2fb">>},
             {<<"/path1/path2%2test">>, <<"/path1/path2%252test">>},
-            {<<"/id/name:107/name2;p=1,3">>, <<"/id/name:107/name2;p=1,3">>}
+            {<<"/id/name:107/name2;p=1,3">>, <<"/id/name:107/name2;p=1,3">>},
+            {<<"/@foobar">>, <<"/@foobar">>}
             ],
     [{V, fun() -> R = hackney_url:pathencode(V) end} || {V, R} <- Tests].
 


### PR DESCRIPTION
In Chromium's [kPathCharLookup][1] table, the commercial at symbol is
given the flag to pass through without being escaped. This is due to
some web services using this character as a delimiter without first unescaping.

[1]: https://src.chromium.org/viewvc/chrome/trunk/src/url/url_canon_path.cc?pathrev=265120#l60