### PR TITLE
Add tests for relative and absolute redirect with a proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ otp_release:
 before_script:
     - "./support/bootstrap_travis.sh"
     - "gunicorn httpbin:app&"
+    - "mitmdump  -p 8001&"
 before_install:
   - sudo pip install -q httpbin
   - sudo pip install -q gunicorn
+  - sudo pip install -q mitmproxy
 script: './rebar3 eunit --dir="test"'

--- a/README.md
+++ b/README.md
@@ -494,22 +494,23 @@ $ rebar3 compile
 ```
 
 For successfully running the hackney test suite locally it is necessary to
-install [httpbin](https://pypi.python.org/pypi/httpbin/0.2.0).
+install [httpbin](https://pypi.python.org/pypi/httpbin/0.2.0) and [mitmproxy](https://pypi.python.org/pypi/mitmproxy).
 
 An example installation using virtualenv::
 
 ```sh
 
 $ mkvirtualenv hackney
-$ pip install gunicorn httpbin
+$ pip install gunicorn httpbin mitmproxy
 
 ```
 
 Running the tests:
 
 ```
+$ mitmdump  -p 8001
 $ gunicorn --daemon --pid httpbin.pid httpbin:app
-$ make test
+$ rebar3 eunit --dir="test"
 $ kill `cat httpbin.pid`
 ```
 

--- a/test/hackney_integration_tests.erl
+++ b/test/hackney_integration_tests.erl
@@ -18,8 +18,10 @@ http_requests_test_() ->
                        send_cookies_request(),
                        absolute_redirect_request_no_follow(),
                        absolute_redirect_request_follow(),
+                       absolute_redirect_request_follow_with_proxy(),
                        relative_redirect_request_no_follow(),
                        relative_redirect_request_follow(),
+                       relative_redirect_request_follow_with_proxy(),
                        async_request(),
                        async_head_request(),
                        async_no_content_request()]}
@@ -100,6 +102,14 @@ absolute_redirect_request_follow() ->
     [?_assertEqual(200, StatusCode),
      ?_assertEqual(<<"http://localhost:8000/get">>, Location)].
 
+absolute_redirect_request_follow_with_proxy() ->
+    URL = <<"http://localhost:8000/redirect-to?url=http://localhost:8000/get">>,
+    Options = [{follow_redirect, true}, {proxy, "http://localhost:8001"}],
+    {ok, StatusCode, _, Client} = hackney:request(get, URL, [], <<>>, Options),
+    Location = hackney:location(Client),
+    [?_assertEqual(200, StatusCode),
+     ?_assertEqual(<<"http://localhost:8000/get">>, Location)].
+
 relative_redirect_request_no_follow() ->
     URL = <<"http://localhost:8000/relative-redirect/1">>,
     Options = [{follow_redirect, false}],
@@ -111,6 +121,14 @@ relative_redirect_request_no_follow() ->
 relative_redirect_request_follow() ->
     URL = <<"http://localhost:8000/redirect-to?url=/get">>,
     Options = [{follow_redirect, true}],
+    {ok, StatusCode, _, Client} = hackney:request(get, URL, [], <<>>, Options),
+    Location = hackney:location(Client),
+    [?_assertEqual(200, StatusCode),
+     ?_assertEqual(<<"/get">>, Location)].
+
+relative_redirect_request_follow_with_proxy() ->
+    URL = <<"http://localhost:8000/relative-redirect/1">>,
+    Options = [{follow_redirect, true}, {proxy, "http://localhost:8001"}],
     {ok, StatusCode, _, Client} = hackney:request(get, URL, [], <<>>, Options),
     Location = hackney:location(Client),
     [?_assertEqual(200, StatusCode),


### PR DESCRIPTION
Add absolute and relative redirect tests using a proxy

I'm getting this message for the relative:

```
127.0.0.1:64644: ProtocolException("Error in HTTP connection: HttpException('Invalid HTTP request form (expected: authority or absolute, got: relative)',)",)
```

```
in function hackney_integration_tests:'-relative_redirect_request_follow_with_proxy/0-fun-0-'/2 
**error:{assertEqual,[{module,hackney_integration_tests},
              {line,134},
              {expression,"StatusCode"},
              {expected,200},
              {value,400}]}
  output:<<"">>
```