### PR TITLE
Fix rebar3 version badmatch

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,7 @@
 IsRebar3 = case application:get_key(rebar, vsn) of
                {ok, VSN} ->
                    [VSN1 | _] = string:tokens(VSN, "-"),
-                   [Maj, Min, Patch] = string:tokens(VSN1, "."),
+                   [Maj, Min, Patch | _] = string:tokens(VSN1, "."),
                    (list_to_integer(Maj) >= 3);
                undefined ->
                    false


### PR DESCRIPTION
Trying to compile with the lastest rebar3 version from https://s3.amazonaws.com/rebar3/rebar3
```
$ ./rebar3 --version
rebar 3.0.0+build.272.ref7d29b74 on Erlang/OTP 18 Erts 7.2.1
```
But it fails with
```
➜ DEBUG=1 ./rebar3 compile
===> Expanded command sequence to be run: [{default,app_discovery},
                                                  {default,install_deps},
                                                  {default,lock},
                                                  {default,compile}]
===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace
===> Uncaught error: {badmatch,
                             {error,
                              {40,file,
                               {error,
                                {badmatch,
                                 ["3","0","0+build","272","ref7d29b74"]},
                                [{erl_eval,expr,3,[]}]}}}}
```