### PR TITLE
Update rebar.config.script to work with Rebar3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,6 +1,6 @@
 IsRebar3 = case application:get_key(rebar, vsn) of
                {ok, VSN} ->
-                   [VSN1 | _] = string:tokens(VSN, "-"),
+                   [VSN1 | _] = string:tokens(VSN, "+"),
                    [Maj, Min, Patch | _] = string:tokens(VSN1, "."),
                    (list_to_integer(Maj) >= 3);
                undefined ->


### PR DESCRIPTION
I found that with the latest Rebar3 I can not `rebar3 compile` anything with Hackney as a dependency via "master" or "1.5.0".

This was uncaught by Rebar3, so I added the following issue for it: https://github.com/erlang/rebar3/issues/1119

To recreate:

    1) `rebar3 new lib testing`
    2) update rebar.config to add hackney dep
    3) `rebar3 compile`

The fix has been simply changing the '-' to '+' as seen here, and I'm wondering if this is a legitimate change to make.

Thank you for your time.