### PR TITLE
hackney_url:normalize function should actually use the function in the argument instead of pathencode()

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -299,9 +299,9 @@ request(Method, URL, Headers, Body) ->
     | {error, term()}.
 request(Method, #hackney_url{}=URL0, Headers, Body, Options0) ->
     PathEncodeFun = proplists:get_value(path_encode_fun, Options0,
-                                        fun hackney_url:encodepath/1),
+                                        fun hackney_url:pathencode/1),
 
-                                            
+
     %% normalize the url encoding
     URL = hackney_url:normalize(URL0, PathEncodeFun),
 

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -222,7 +222,7 @@ request(Method, URL, Headers, Body) ->
 %%      `hackney:stream_next/1'
 %%      </li>
 %%      <li>`{path_encode_fun, fun()}': function used to encode the path. if
-%%      not set it will use `hackney_url:path_encode/1' the function takes the
+%%      not set it will use `hackney_url:pathencode/1' the function takes the
 %%      binary path as entry and return a new encoded path.</li>
 %%
 %%      <li>`{stream_to, pid()}': If async is true or once, the response

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -101,7 +101,7 @@ normalize(#hackney_url{}=Url, Fun) when is_function(Fun, 1) ->
             end,
             {Host2, Netloc1}
     end,
-    Path1 = pathencode(Path),
+    Path1 = Fun(Path),
     Url#hackney_url{host=Host, netloc=Netloc, path=Path1}.
 
 transport_scheme(hackney_tcp_transport) ->


### PR DESCRIPTION
from https://github.com/benoitc/hackney/issues/272