### PR TITLE
faster.

### DIFF
--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -367,9 +367,8 @@ fix_path(Path) ->
 %% @equiv pathencode(Bin, [])
 -spec pathencode(binary()) -> binary().
 pathencode(Bin) ->
-    Parts = re:split(hackney_bstr:to_binary(Bin), <<"/">>,
-                     [{return, binary}]),
-	do_partial_pathencode(Parts, []).
+    Parts = binary:split(hackney_bstr:to_binary(Bin), <<"/">>, [global]),
+    do_partial_pathencode(Parts, []).
 
 do_partial_pathencode([], Acc) ->
     hackney_bstr:join(lists:reverse(Acc), <<"/">>);


### PR DESCRIPTION
  timer:tc(fun () -> binary:split(<<"foo/bar/baz">>, <<"/">>, [global]) end).
{44,[<<"foo">>,<<"bar">>,<<"baz">>]}

  timer:tc(fun () -> binary:split(<<"foo/bar/baz">>, <<"/">>, [global]) end).
{40,[<<"foo">>,<<"bar">>,<<"baz">>]}

versus:

  timer:tc(fun () -> re:split(<<"foo/bar/baz">>, <<"/">>, [{return, binary}]) end).
{4335,[<<"foo">>,<<"bar">>,<<"baz">>]}

  timer:tc(fun () -> re:split(<<"foo/bar/baz">>, <<"/">>, [{return, binary}]) end).
{96,[<<"foo">>,<<"bar">>,<<"baz">>]}