### PR TITLE
Close #291: Fix typos for configuring exometer metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ API matching that of the hackney metrics module.
 To  use [folsom](https://github.com/boundary/folsom), specify `{mod_metrics,
 folsom}`, or if you want to use
 [exometer](https://github.com/feuerlabs/exometer), specify`{mod_metrics,
-exometers}` and ensure that folsom or exometer is in your code path and has
+exometer}` and ensure that folsom or exometer is in your code path and has
 been started.
 
 #### Generic Hackney metrics

--- a/doc/README.md
+++ b/doc/README.md
@@ -443,7 +443,7 @@ API matching that of the hackney metrics module.
 To  use [folsom](https://github.com/boundary/folsom), specify `{mod_metrics,
 folsom}`, or if you want to use
 [exometer](https://github.com/feuerlabs/exometer), specify`{mod_metrics,
-exometers}` and ensure that folsom or exometer is in your code path and has
+exometer}` and ensure that folsom or exometer is in your code path and has
 been started.
 
 #### Generic Hackney metrics

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -444,7 +444,7 @@ API matching that of the hackney metrics module.
 To  use [folsom](https://github.com/boundary/folsom), specify `{mod_metrics,
 folsom}', or if you want to use
 [exometer](https://github.com/feuerlabs/exometer), specify  `{mod_metrics,
-exometers}' and ensure that folsom or exometer is in your code path and has
+exometer}' and ensure that folsom or exometer is in your code path and has
 been started.
 
 

--- a/src/hackney_util.erl
+++ b/src/hackney_util.erl
@@ -103,7 +103,7 @@ privdir() ->
 mod_metrics() ->
     case application:get_env(hackney, mod_metrics) of
         {ok, folsom} -> metrics_folsom;
-        {ok, exometer} -> metrics_exometers;
+        {ok, exometer} -> metrics_exometer;
         {ok, dummy} -> metrics_dummy;
         {ok, Mod} -> Mod;
         _ -> metrics_dummy


### PR DESCRIPTION
This updates the exometer configuration instructions in the
README to match the term that `mod_metrics` expects in order
to enable exometer metrics.

This also updates `mod_metrics` so that the module name used
when exometer metrics are enabled matches the name of the
module that is provided by the metrics library.