### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ use Mix.Project
             app: :hackney,
             version: "1.6.0",
             description: "simple HTTP client for the Erlang VM",
-            deps: deps,
-            package: package,
+            deps: deps(),
+            package: package(),
             language: :erlang
         ]
     end


### PR DESCRIPTION
Use parenthesis to remove the ambiguity with variables.