### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ use Mix.Project
             app: :hackney,
             version: "1.6.0",
             description: "simple HTTP client for the Erlang VM",
-            deps: deps,
-            package: package,
+            deps: deps(),
+            package: package(),
             language: :erlang
         ]
     end


### PR DESCRIPTION
For people using Elixir master (which is `1.4.0-dev` at the time of writing), `mix.exs` will warn because there are a couple of local 0-arity functions called without parentheses. This fixes that :)