### PR TITLE
support for UDS on Erlang 19, using 'http+unix' scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ otp_release:
   - R16B
 before_script:
     - "./support/bootstrap_travis.sh"
-    - "gunicorn httpbin:app&"
+    - "gunicorn -b 127.0.0.1:8000 -b unix:httpbin.sock httpbin:app&"
 before_install:
   - sudo pip install -q httpbin
   - sudo pip install -q gunicorn

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ $ pip install gunicorn httpbin
 Running the tests:
 
 ```
-$ gunicorn --daemon --pid httpbin.pid httpbin:app
+$ gunicorn -b 127.0.0.1:8000 -b unix:httpbin.sock --daemon --pid httpbin.pid httpbin:appl
 $ make test
 $ kill `cat httpbin.pid`
 ```
@@ -541,4 +541,3 @@ $ kill `cat httpbin.pid`
 <tr><td><a href="http://github.com/benoitc/hackney/blob/master/doc/hackney_trace.md" class="module">hackney_trace</a></td></tr>
 <tr><td><a href="http://github.com/benoitc/hackney/blob/master/doc/hackney_url.md" class="module">hackney_url</a></td></tr>
 <tr><td><a href="http://github.com/benoitc/hackney/blob/master/doc/hackney_util.md" class="module">hackney_util</a></td></tr></table>
-

--- a/src/hackney_local_transport.erl
+++ b/src/hackney_local_transport.erl
@@ -27,8 +27,8 @@ connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
 	(Timeout =:= infinity orelse is_integer(Timeout)) ->
 
     %% filter options
-    AcceptedOpts =  [linger, nodelay, keepalive, send_timeout,
-                     send_timeout_close, raw, inet6, reuseaddr,
+    AcceptedOpts =  [nodelay, keepalive, send_timeout,
+                     send_timeout_close, raw, reuseaddr,
                      ip, ip_address],
     BaseOpts = [binary, {active, false}, {packet, raw}],
     Opts1 = hackney_util:filter_options(Opts, AcceptedOpts, BaseOpts),

--- a/src/hackney_local_transport.erl
+++ b/src/hackney_local_transport.erl
@@ -1,0 +1,93 @@
+%%% -*- erlang -*-
+%%%
+%%% This file is part of hackney released under the Apache 2 license.
+%%% See the NOTICE for more information.
+%%%
+%%% Copyright (c) 2011-2012, Loïc Hoguin <essen@ninenines.eu>
+%%%
+-module(hackney_local_transport).
+-export([messages/1,
+         connect/3, connect/4,
+         recv/2, recv/3,
+         send/2,
+         setopts/2,
+         controlling_process/2,
+         peername/1,
+         close/1,
+         shutdown/2,
+         sockname/1]).
+
+%% @doc Atoms used to identify messages in {active, once | true} mode.
+messages(_) -> {tcp, tcp_closed, tcp_error}.
+
+connect(Host, Port, Opts) ->
+	connect(Host, Port, Opts, infinity).
+
+connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
+	(Timeout =:= infinity orelse is_integer(Timeout)) ->
+
+    %% filter options
+    AcceptedOpts =  [linger, nodelay, keepalive, send_timeout,
+                     send_timeout_close, raw, inet6, reuseaddr,
+                     ip, ip_address],
+    BaseOpts = [binary, {active, false}, {packet, raw}],
+    Opts1 = hackney_util:filter_options(Opts, AcceptedOpts, BaseOpts),
+
+    %% connect
+    gen_tcp:connect({local, Host}, Port, Opts1, Timeout).
+
+recv(Socket, Length) ->
+    recv(Socket, Length, infinity).
+
+%% @doc Receive a packet from a socket in passive mode.
+%% @see gen_tcp:recv/3
+-spec recv(inet:socket(), non_neg_integer(), timeout())
+	-> {ok, any()} | {error, closed | atom()}.
+recv(Socket, Length, Timeout) ->
+	gen_tcp:recv(Socket, Length, Timeout).
+
+
+%% @doc Send a packet on a socket.
+%% @see gen_tcp:send/2
+-spec send(inet:socket(), iolist()) -> ok | {error, atom()}.
+send(Socket, Packet) ->
+	gen_tcp:send(Socket, Packet).
+
+%% @doc Set one or more options for a socket.
+%% @see inet:setopts/2
+-spec setopts(inet:socket(), list()) -> ok | {error, atom()}.
+setopts(Socket, Opts) ->
+	inet:setopts(Socket, Opts).
+
+%% @doc Assign a new controlling process <em>Pid</em> to <em>Socket</em>.
+%% @see gen_tcp:controlling_process/2
+-spec controlling_process(inet:socket(), pid())
+	-> ok | {error, closed | not_owner | atom()}.
+controlling_process(Socket, Pid) ->
+	gen_tcp:controlling_process(Socket, Pid).
+
+%% @doc Return the address and port for the other end of a connection.
+%% @see inet:peername/1
+-spec peername(inet:socket())
+	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
+peername(Socket) ->
+	inet:peername(Socket).
+
+%% @doc Close a TCP socket.
+%% @see gen_tcp:close/1
+-spec close(inet:socket()) -> ok.
+close(Socket) ->
+	gen_tcp:close(Socket).
+
+%% @doc Immediately close a socket in one or two directions.
+%% @see gen_tcp:shutdown/2
+-spec shutdown(inet:socket(), read | write | read_write) -> ok.
+shutdown(Socket, How) ->
+    gen_tcp:shutdown(Socket, How).
+
+%% @doc Get the local address and port of a socket
+%% @see inet:sockname/1
+-spec sockname(inet:socket())
+	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
+sockname(Socket) ->
+	inet:sockname(Socket).

--- a/test/hackney_integration_tests.erl
+++ b/test/hackney_integration_tests.erl
@@ -22,7 +22,8 @@ http_requests_test_() ->
                        relative_redirect_request_follow(),
                        async_request(),
                        async_head_request(),
-                       async_no_content_request()]}
+                       async_no_content_request(),
+                       local_socket_request()]}
      end}.
 
 start() ->
@@ -139,6 +140,11 @@ async_no_content_request() ->
     {StatusCode, Keys} = receive_response(ClientRef),
     [?_assertEqual(204, StatusCode),
      ?_assertEqual([headers, status], Keys)].
+
+local_socket_request() ->
+    URL = <<"http+unix://httpbin.sock/get">>,
+    {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, []),
+    ?_assertEqual(200, StatusCode).
 
 %% Helpers
 

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -122,6 +122,19 @@ parse_and_unparse_url_test_() ->
                           port = 443,
                           user = <<"user">>,
                           password = <<"">>}
+            },
+            {<<"http+unix://user@%2Fvar%2Frun%2Ftest.sock/path?key=value#Section%205">>,
+             #hackney_url{transport =hackney_local_transport,
+                          scheme = http_unix,
+                          netloc = <<"%2Fvar%2Frun%2Ftest.sock">>,
+                          raw_path = <<"/path?key=value#Section%205">>,
+                          path = <<"/path">>,
+                          qs = <<"key=value">>,
+                          fragment = <<"Section%205">>,
+                          host = "/var/run/test.sock",
+                          port = 0,
+                          user = <<"user">>,
+                          password = <<"">>}
             }
             ],
     [{V, fun() -> R = hackney_url:parse_url(V) end} || {V, R} <- Tests] ++


### PR DESCRIPTION
I've only added limited test coverage for now. If I'm on the right track and this is something you'll consider merging I'll be happy to try and add some more tests and docs.

Note that I've had to override the Host header in requests I sent to the Docker engine, because it doesn't like the default Host header built by Hackney from the `netloc` of http+unix URLs. That could potentialy be handled in `host_header/2`.