### PR TITLE
Remove warnings

### DIFF
--- a/src/hackney_multipart.erl
+++ b/src/hackney_multipart.erl
@@ -268,7 +268,7 @@ mp_data_header({Name, Len, {Disposition, Params}, ExtraHeaders}, Boundary) ->
 unique(Size) -> unique(Size, <<>>).
 unique(0, Acc) -> Acc;
 unique(Size, Acc) ->
-  Random = $a + random:uniform($z - $a),
+  Random = $a + rand:uniform($z - $a),
   unique(Size - 1, <<Acc/binary, Random>>).
 
 decode_form1(eof, [[]|Acc]) ->

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -210,7 +210,7 @@ init([Name, Options]) ->
         true ->
             % Make sure that the ssl random number generator is seeded
             % This was new in R13 (ssl-3.10.1 in R13B vs. ssl-3.10.0 in R12B-5)
-            apply(ssl, seed, [crypto:rand_bytes(255)]);
+            apply(ssl, seed, [crypto:strong_rand_bytes(255)]);
         false ->
             ok
     end,


### PR DESCRIPTION
These two warnings should no longer appear:
```
src/hackney_pool.erl:213: Warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
src/hackney_multipart.erl:271: Warning: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
```