### PR TITLE
Update mix version to reflect the version increment to 1.6.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ use Mix.Project
     def project do
         [
             app: :hackney,
-            version: "1.6.0",
+            version: "1.6.1",
             description: "simple HTTP client for the Erlang VM",
             deps: deps(),
             package: package(),


### PR DESCRIPTION
All the docs say that the current version is 1.6.1  Make this match what is on hex.pm.