### PR TITLE
Fix hackney_util:merge_opts/2

### DIFF
--- a/src/hackney_util.erl
+++ b/src/hackney_util.erl
@@ -139,7 +139,7 @@ have_rand() -> (code:which(rand) /= non_existing).
 
 merge_opts([], Options) -> Options;
 merge_opts([Opt = {K, _}| Rest], Options) ->
-	case lists:member(K, Options) of
+	case lists:keymember(K, 1, Options) of
 		true -> merge_opts(Rest, Options);
 		false -> merge_opts(Rest, [Opt | Options])
 	end;


### PR DESCRIPTION
For tuples lists:keymember/3 should be used instead of lists:member/2.