### PR TITLE
prevent errors by handle trailing whitespace in header values

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -319,12 +319,8 @@ parse_header(Line, St) ->
     end,
     {header, {Key, Value}, St1}.
 
-parse_header_value(<< $\s, Rest/binary >>) ->
-    parse_header_value(Rest);
-parse_header_value(<< $\t, Rest/binary >>) ->
-    parse_header_value(Rest);
 parse_header_value(H) ->
-    H.
+    hackney_bstr:trim(H).
 
 
 parse_trailers(St, Acc) ->
@@ -525,3 +521,16 @@ get_property(content_type, #hparser{ctype=CType}) ->
     CType;
 get_property(location, #hparser{location=Location}) ->
     Location.
+
+%%% Private Tests
+-ifdef(TEST).
+
+    -include_lib("eunit/include/eunit.hrl").
+
+    parse_response_header_with_trailing_whitespace_test() ->
+        Response = <<"Content-Length: 27515  ">>,
+        Parser1 = parser([response]),
+        {header, {<<"Content-Length">>, Length}, _} = parse_header(Response, Parser1),
+        ?assertEqual(<<"27515">>, Length).
+
+-endif.


### PR DESCRIPTION
I was occasionally seeing errors in an Elixir project that I traced back to hackney. The most reliable way to see a failure was requesting http://www.apple.com Seems they sometimes are responding with a Content-Length value that had trailing whitespace.

This was the hackney error:
```
iex(1)> :hackney.get "http://www.apple.com"
** (ArgumentError) argument error
              :erlang.list_to_integer('27515     ')
    (hackney) /Users/rich/Projects/elixir/whistle/deps/hackney/src/hackney_response.erl:106: :hackney_response.wait_headers/4
    (hackney) /Users/rich/Projects/elixir/whistle/deps/hackney/src/hackney.erl:368: :hackney.send_request/2
```

I added a test directly into the `hackney_http` module because `parse_header/2` is not exported. If this is not the correct approach, I'm happy to fix; I'm new to both Elixir and Erlang.