### PR TITLE
Fix a few documentation typos

### DIFF
--- a/doc/hackney_multipart.md
+++ b/doc/hackney_multipart.md
@@ -154,7 +154,7 @@ encode a list of parts a multiart form.
 Parts can be under the form:
 - `{file, Path}` : to send a file
 - `{file, Path, ExtraHeaders}` : to send a file with extra headers
-- `{mp_mixed, Name, Boundart}` to send a mixed multipart.
+- `{mp_mixed, Name, Boundary}` to send a mixed multipart.
 - `{mp_mixed_eof, Boundary}`: to signal the end of the mixed
 multipart boundary.
 - `{Name, Data}`: to send a custom content as a part
@@ -183,7 +183,7 @@ transfer-encoding instead of chunked so any server can handle it.
 Calculated Parts can be under the form:
 - `{file, Path}` : to send a file
 - `{file, Path, ExtraHeaders}` : to send a file with extra headers
-- `{mp_mixed, Name, Boundart}` to send a mixed multipart.
+- `{mp_mixed, Name, Boundary}` to send a mixed multipart.
 multipart boundary.
 - `{Name, DataLen}`: to send a custom content as a part
 - `{Name, DataLen, ExtraHeaders}`: the same as above but with extra

--- a/src/hackney_multipart.erl
+++ b/src/hackney_multipart.erl
@@ -42,7 +42,7 @@
 %% Parts can be under the form:
 %%  - `{file, Path}' : to send a file
 %%  - `{file, Path, ExtraHeaders}' : to send a file with extra headers
-%%  - `{mp_mixed, Name, Boundart}' to send a mixed multipart.
+%%  - `{mp_mixed, Name, Boundary}' to send a mixed multipart.
 %%  - `{mp_mixed_eof, Boundary}': to signal the end of the mixed
 %%  multipart boundary.
 %%  - `{Name, Data}': to send a custom content as a part
@@ -150,7 +150,7 @@ part(Content, Headers, Boundary) ->
 %% Calculated Parts can be under the form:
 %%  - `{file, Path}' : to send a file
 %%  - `{file, Path, ExtraHeaders}' : to send a file with extra headers
-%%  - `{mp_mixed, Name, Boundart}' to send a mixed multipart.
+%%  - `{mp_mixed, Name, Boundary}' to send a mixed multipart.
 %%  multipart boundary.
 %%  - `{Name, DataLen}': to send a custom content as a part
 %%  - `{Name, DataLen, ExtraHeaders}': the same as above but with extra


### PR DESCRIPTION
From `Boundart` to `Boundary`.
