### PR TITLE
Handle continuation lines in HTTP headers correctly

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -280,11 +280,11 @@ parse_header(#hparser{buffer=Buf}=St) ->
         [<<>>, Rest] ->
             {headers_complete, St#hparser{buffer=Rest,
                                           state=on_body}};
-        [<< " ", Line/binary >>, Rest] ->
-            NewBuf = iolist_to_binary([Line, Rest]),
+        [Line, << " ", Rest/binary >> ] ->
+            NewBuf = iolist_to_binary([Line, " ", Rest]),
             parse_header(St#hparser{buffer=NewBuf});
-        [<< "\t", Line/binary >>, Rest] ->
-            NewBuf = iolist_to_binary([Line, Rest]),
+        [Line, << "\t", Rest/binary >> ] ->
+            NewBuf = iolist_to_binary([Line, " ", Rest]),
             parse_header(St#hparser{buffer=NewBuf});
         [Line, Rest]->
             parse_header(Line, St#hparser{buffer=Rest});

--- a/test/hackney_http_tests.erl
+++ b/test/hackney_http_tests.erl
@@ -22,3 +22,11 @@ parse_response_missing_reason_phrase_test() ->
 	{response, _Version, StatusInt, Reason, _NState} =  hackney_http:parse_response_version(Response, St),
 	?assertEqual(StatusInt, 200),
 	?assertEqual(Reason, <<"">>).
+
+parse_response_header_with_continuation_line_test() ->
+	Response = <<"HTTP/1.1 200\r\nContent-Type: multipart/related;\r\n\tboundary=\"--:\"\r\n\r\n">>,
+	ST1 = #hparser{},
+	{response, _Version, _StatusInt, _Reason, ST2} = hackney_http:execute(ST1, Response),
+	{header, Header, ST3} = hackney_http:execute(ST2),
+	?assertEqual({<<"Content-Type">>, <<"multipart/related; boundary=\"--:\"">>}, Header),
+	{headers_complete, _ST4} = hackney_http:execute(ST3).


### PR DESCRIPTION
[RFC2616 says](https://pretty-rfc.herokuapp.com/RFC2616#basic.rules):

> HTTP/1.1 header field values can be folded onto multiple lines if the
> continuation line begins with a space or horizontal tab. All linear
> white space, including folding, has the same semantics as SP. A
> recipient MAY replace any linear white space with a single SP before
> interpreting the field value or forwarding the message downstream.
>
> LWS            = [CRLF] 1*( SP | HT )
>
> SP             = <US-ASCII SP, space (32)>
> HT             = <US-ASCII HT, horizontal-tab (9)>

Hackney was not handling this correctly: it was stripping leading spaces
and tabs from continuation lines and then parsing them incorrectly as a
new header line.

This commit fixes that: `parse_header/1` now checks if the following
line starts with a space or tab and joins it onto the current line if
so.