### PR TITLE
correct hackney:connect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ couple of requests.
 ```erlang
 
 Transport = hackney_tcp,
-Host = << "https://friendpaste.com" >>,
+Host = << "friendpaste.com" >>,
 Port = 443,
 Options = [],
 {ok, ConnRef} = hackney:connect(Transport, Host, Port, Options)


### PR DESCRIPTION
Do not include the protocol in the `Host` or it will
be considered part of the host name--this results in an
`nxdomain` error.