### PR TITLE
fix connection leak

### DIFF
--- a/src/hackney_http_connect.erl
+++ b/src/hackney_http_connect.erl
@@ -65,12 +65,14 @@ connect(ProxyHost, ProxyPort, Opts, Timeout)
                 {ok, SslSocket} ->
                   {ok, {Transport, SslSocket}};
                 Error ->
+                  gen_tcp:close(Socket),
                   Error
               end;
             _ ->
               {ok, {Transport, Socket}}
           end;
         Error ->
+          gen_tcp:close(Socket),
           Error
       end;
     Error ->

--- a/src/hackney_socks5.erl
+++ b/src/hackney_socks5.erl
@@ -62,12 +62,14 @@ connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
                 {ok, SslSocket} ->
                   {ok, {Transport, SslSocket}};
                 Error ->
+                  gen_tcp:close(Socket),
                   Error
               end;
             _ ->
               {ok, {Transport, Socket}}
           end;
         Error ->
+          gen_tcp:close(Socket),
           Error
       end;
     Error ->


### PR DESCRIPTION
steps to reproduce

start a proxy server that responds with error for any connect request.

```elixir
defmodule ProxyServer do
  require Logger
  def accept(port) do
    {:ok, socket} = :gen_tcp.listen(port,
                      [:binary, packet: :line, active: true, reuseaddr: true])
    Logger.info "Accepting connections on port #{port}"
    loop_acceptor(socket)
  end

  defp loop_acceptor(socket) do
    {:ok, client} = :gen_tcp.accept(socket)
    spawn(fn -> write_line(client) end)
    loop_acceptor(socket)
  end

  defp write_line(socket) do
    :gen_tcp.send(socket, "HTTP/1.0 404 Not Found\r\nServer: squid/3.1.23\r\nMime-Version: 1.0\r\nDate: Sat, 04 Mar 2017 19:16:09 GMT\r\nContent-Type: text/html\r\nContent-Length: 3402\r\nX-Squid-Error: ERR_DNS_FAIL 0\r\nVary: Accept-Language\r\nContent-Language: en\r\n\r\n")
  end
end
ProxyServer.accept(5000)
```

make 100 requests.

```elixir
Application.ensure_all_started(:hackney)
IO.inspect "==============> before: #{:erlang.system_info(:port_count)}"
for _i <- 1..100 do
    IO.inspect :hackney.post("https://echo.getpostman.com/post", [], "ping", [:with_body, {:pool, false}, {:proxy, {'127.0.0.1', 5000}}])
end
IO.inspect "==============> after: #{:erlang.system_info(:port_count)}"
```

without patch
```
"==============> after: 107"
```

with patch
```
"==============> after: 7"
```