### PR TITLE
uses the connect timeout for the checkout call

### DIFF
--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -58,12 +58,12 @@ start() ->
 
 %% @doc fetch a socket from the pool
 checkout(Host0, Port, Transport, #client{options=Opts}=Client) ->
-  ConnectTimeout = proplists:get_value(connect_timeout, Opts, 8000),
   Host = string:to_lower(Host0),
   Pid = self(),
   RequestRef = Client#client.request_ref,
   Name = proplists:get_value(pool, Opts, default),
   Pool = find_pool(Name, Opts),
+  ConnectTimeout = proplists:get_value(connect_timeout, Opts, 8000),
   case catch gen_server:call(Pool, {checkout, {Host, Port, Transport},
     Pid, RequestRef}, ConnectTimeout) of
     {ok, Socket, Owner} ->

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -64,8 +64,8 @@ checkout(Host0, Port, Transport, #client{options=Opts}=Client) ->
   RequestRef = Client#client.request_ref,
   Name = proplists:get_value(pool, Opts, default),
   Pool = find_pool(Name, Opts),
-  case catch gen_server:call(Pool, {checkout, {Host, Port, Transport}, Pid,
-      RequestRef}, ConnectTimeout) of
+  case catch gen_server:call(Pool, {checkout, {Host, Port, Transport},
+    Pid, RequestRef}, ConnectTimeout) of
     {ok, Socket, Owner} ->
       CheckinReference = {Host, Port, Transport},
       {ok, {Name, RequestRef, CheckinReference, Owner, Transport}, Socket};

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -64,12 +64,8 @@ checkout(Host0, Port, Transport, #client{options=Opts}=Client) ->
   RequestRef = Client#client.request_ref,
   Name = proplists:get_value(pool, Opts, default),
   Pool = find_pool(Name, Opts),
-  Connection = case catch gen_server:call(Pool, {checkout,
-      {Host, Port, Transport}, Pid, RequestRef}, ConnectTimeout) of
-    {'EXIT', {timeout, _}} -> {error, connect_timeout};
-    Conn -> Conn
-  end,
-  case Connection of
+  case catch gen_server:call(Pool, {checkout, {Host, Port, Transport}, Pid,
+      RequestRef}, ConnectTimeout) of
     {ok, Socket, Owner} ->
       CheckinReference = {Host, Port, Transport},
       {ok, {Name, RequestRef, CheckinReference, Owner, Transport}, Socket};
@@ -77,9 +73,9 @@ checkout(Host0, Port, Transport, #client{options=Opts}=Client) ->
       CheckinReference = {Host, Port, Transport},
       {error, no_socket, {Name, RequestRef, CheckinReference, Owner,
         Transport}};
-    
     {error, Reason} ->
-      {error, Reason}
+      {error, Reason};
+    {'EXIT', {timeout, _}} -> {error, connect_timeout}
   end.
 
 %% @doc release a socket in the pool

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -67,7 +67,7 @@ checkout(Host0, Port, Transport, #client{options=Opts}=Client) ->
   Connection = case catch gen_server:call(Pool, {checkout,
       {Host, Port, Transport}, Pid, RequestRef}, ConnectTimeout) of
     {'EXIT', {timeout, _}} -> {error, connect_timeout};
-    Error -> Error
+    Conn -> Conn
   end,
   case Connection of
     {ok, Socket, Owner} ->


### PR DESCRIPTION
We were experiencing request calls that hung indefinitely due to connections not being available in the pool. Similar to issue https://github.com/benoitc/hackney/issues/391

The hackney_pool should now respect the connect_timeout setting and returns an {error, connect_timeout}

Is this a good way to handle this? Would you like me to adds some tests?

