### PR TITLE
fixed race condition controlling_process

### DIFF
--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -167,9 +167,12 @@ start_async_response(Ref) ->
           %% delete the current state from the process dictionnary
           %% since it's not the owner
           erase(Ref),
-          
+
           %% transfert the control of the socket
-          Transport:controlling_process(Socket, Pid);
+          case Transport:controlling_process(Socket, Pid) of
+            ok -> Pid ! controlling_process_done, ok;
+            Else -> Else
+          end;
         Error ->
           Error
       end

--- a/src/hackney_stream.erl
+++ b/src/hackney_stream.erl
@@ -25,6 +25,8 @@ init(Parent, Owner, Ref, Client) ->
   %% register the stream
   ok = proc_lib:init_ack(Parent, {ok, self()}),
 
+  ok = wait_for_controlling_process(),
+
   Parser = hackney_http:parser([response]),
   try
     stream_loop(Parent, Owner, Ref, Client#client{parser=Parser,
@@ -34,6 +36,14 @@ init(Parent, Owner, Ref, Client) ->
       {{Class, Reason,
         erlang:get_stacktrace()},
         "An unexpected error occurred."}}}}
+  end.
+
+wait_for_controlling_process() ->
+  receive
+    controlling_process_done ->
+      ok
+  after 10000 ->
+    timeout
   end.
 
 stream_loop(Parent, Owner, Ref, #client{transport=Transport,


### PR DESCRIPTION
Sometimes {active,once} is too fast, => active is then false and controlling_process does not transfer the message sending to current process to hackney_stream.
Due to this we get an timeout:

2017-05-12 11:21:54 =CRASH REPORT====
  crasher:
    initial call: couchbeam_changes_stream:init_stream/5
    pid: <0.4354.0>
    registered_name: []
    exception exit: {timeout,[{couchbeam_changes_stream,do_init_stream,1,[{file,"couchbeam_changes_stream.erl"},{line,151}]},{couchbeam_changes_stream,init_stream,5,[{file,"couchbeam_changes_stream.erl"},{line,85}]}]}
    ancestors: [couchbeam_changes_sup,couchbeam_sup,<0.1303.0>]
    messages: [{ssl,{sslsocket,{gen_tcp,#Port<0.21588>,tls_connection,undefined},<0.4357.0>},<<"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nServer: CouchDB/1.6.1 (Erlang OTP/19)\r\nDate: Fri, 12 May 2017 09:21:32 GMT\r\nContent-Type: application/json\r\nCache-Control: must-revalidate\r\n\r\n">>}]
    links: [<0.1299.0>,<0.1311.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 1598
    stack_size: 27
    reductions: 8605