### PR TITLE
Undefined function hackney:start/0 which is described in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ application:start(crypto),
 application:start(public_key),
 application:start(ssl),
 %% Then:
-application:start(hackney).
+application:ensure_all_started(hackney).
 ```
 
 Or add hackney to the applications property of your .app in a release

--- a/README.md
+++ b/README.md
@@ -102,17 +102,18 @@ This fixes zsh (and maybe other shells) escript-related bugs. Also this should s
 
 ```erlang-repl
 
-1>> hackney:start().
+1> hackney:start().
 ok
 ```
 
 It will start hackney and all of the application it depends on:
 
 ```erlang
-
+%% If you specified {ssl, true} in application environment:
 application:start(crypto),
 application:start(public_key),
 application:start(ssl),
+%% Then:
 application:start(hackney).
 ```
 

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -52,7 +52,7 @@
 
 
 start() ->
-  case hackney:get_app_env(ssl, false) of
+  case hackney_app:get_app_env(ssl, false) of
     true ->
       application:start(crypto),
       application:start(public_key),

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -6,7 +6,8 @@
 
 -module(hackney).
 
--export([connect/1, connect/2, connect/3, connect/4,
+-export([start/0,
+         connect/1, connect/2, connect/3, connect/4,
          close/1,
          request_info/1,
          location/1,
@@ -48,6 +49,18 @@
 
 -type client_ref() :: term().
 -export_type([client_ref/0]).
+
+
+start() ->
+  case hackney:get_app_env(ssl, false) of
+    true ->
+      application:start(crypto),
+      application:start(public_key),
+      application:start(ssl);
+    _ ->
+      ok
+  end,
+  application:start(hackney).
 
 connect(URL) ->
   connect(URL, []).

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -54,9 +54,9 @@
 start() ->
   case hackney_app:get_app_env(ssl, false) of
     true ->
-      application:start(crypto),
-      application:start(public_key),
-      application:start(ssl);
+      _ = application:start(crypto),
+      _ = application:start(public_key),
+      _ = application:start(ssl);
     _ ->
       ok
   end,

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -61,7 +61,7 @@ start() ->
       _ ->
         ok
     end,
-  application:start(hackney).
+  application:ensure_all_started(hackney).
 
 connect(URL) ->
   connect(URL, []).

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -52,14 +52,15 @@
 
 
 start() ->
-  case hackney_app:get_app_env(ssl, false) of
-    true ->
-      _ = application:start(crypto),
-      _ = application:start(public_key),
-      _ = application:start(ssl);
-    _ ->
-      ok
-  end,
+  _ = 
+    case hackney_app:get_app_env(ssl, false) of
+      true ->
+        _ = application:start(crypto),
+        _ = application:start(public_key),
+        _ = application:start(ssl);
+      _ ->
+        ok
+    end,
   application:start(hackney).
 
 connect(URL) ->


### PR DESCRIPTION
If `{ssl, true}` specified in application environment `hackney:start/0` starts `crypto`, `public_key` and `ssl` before starting `hackney`, otherwise just starts `hackney`.