### PR TITLE
use 'unite' for eunit error formatting

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,8 @@
 {xref_checks, [undefined_function_calls]}.
 
 {cover_enabled, true}.
-{eunit_opts, [verbose]}.
+{eunit_opts, [verbose, no_tty, {report, {unite_compact, []}}]}.
+
 
 {post_hooks, [{clean, "rm -rf *~ */*~ */*.xfm test/*.beam"}]}.
 
@@ -34,7 +35,7 @@
                            {top_level_readme,
                             {"./README.md", "http://github.com/benoitc/hackney"}}]}]},
              {test, [
-               {deps, [{cowboy, "1.0.4"}, {jsone, "1.4.3"}]}
+               {deps, [{cowboy, "1.0.4"}, {jsone, "1.4.3"}, {unite, {git, "git://github.com/binarytemple/unite.git",{branch, "patch-1"}}}]}
              ]}
            ]}.
 


### PR DESCRIPTION
'unite' provides way nicer error output from 'eunit' tests - one thing I found particularly useful when hacking on hackney was the fact that it provides diff'd output on 'assertEqual' assertions whereas the default output formatter truncates the output. 

A follow up P/R will patch the unit tests to use assertions rather than equality checks, e.g:

```
 [{V, fun() -> ?assertMatch(R,hackney_url:parse_url(V)) end} || {V, R} <- Tests] ++
```


I have an active [P/R](https://github.com/eproxus/unite/pull/10) with eproxus to correct a unhandled case statement - this dependency is to my patched version.

Examples: 

```
1) "module 'hackney_integration_tests'"                              
    get_request/0 (/common/hackney/_build/test/lib/hackney/test/hackney_integration_tests.erl:49)                                            
    Instantiation failed:          
    exception error: no match of right hand side value {error,econnrefused}                                                                        in function  hackney_integration_tests:get_request/0 (/common/hackney/_build/test/lib/hackney/test/hackney_integration_tests.erl, line 49)
      in call from hackney_integration_tests:all_tests/0 (/common/hackney/_build/test/lib/hackney/test/hackney_integration_tests.erl, line 7)      in call from hackney_integration_tests:'-http_requests_test_/0-fun-2-'/1 (/common/hackney/_build/test/lib/hackney/test/hackney_integration_tests.erl, line 38)

151 tests passed  1 fixture cancelled  (0.93 s)                       
===> Error running tests
```
        
('assertMatch') 

```
 1) "http://www.example.com/path?key=value#Section%205"
    parse_and_unparse_url_test_/0 (/common/hackney/_build/test/lib/hackney/test/hackney_url_tests.erl:140)
    Assert match failed!
    Expression:
        hackney_url:parse_url(V)
    Pattern:
        R
    Actual:
        {hackney_url,hackney_tcp,http,<<"www.example.com">>,
                     <<"/path?key=value#Section%205">>,<<"/path">>,
                     <<"key=value">>,<<"Section%205">>,"www.example.com",80,
                     <<>>,<<>>}
```