### PR TITLE
Hackney pool handler connect not set when creating new connection

### DIFF
--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -199,8 +199,9 @@ socket_from_pool(Host, Port, Transport, Client0) ->
     {error, no_socket, Ref} ->
       ?report_trace("no socket in the pool", [{pool, PoolName}]),
       _ = metrics:increment_counter(Metrics, [hackney_pool, PoolName, no_socket]),
-      do_connect(Host, Port, Transport, Client#client{socket_ref=Ref},
-        pool);
+      Client1 = Client#client{socket_ref=Ref, pool_handler=PoolHandler},
+
+      do_connect(Host, Port, Transport, Client1, pool);
     Error ->
       Error
   end.

--- a/src/hackney_pool_handler.erl
+++ b/src/hackney_pool_handler.erl
@@ -24,18 +24,23 @@ behaviour_info(_) ->
 
 -else.
 
-%% start a bool handler
+%% start a pool handler
 -callback start() -> ok | {error, Reason :: any()}.
 
+%% checkout a connection for use
 -callback checkout(Host::host(), Port::integer(),Transport::atom(),
   Client::client()) ->
   {ok, {Info::any(), CheckingReference::any(), Owner::pid(),
     Transport::atom()}, Socket::inet:socket()}
   | {error, Reason :: any()}.
 
+%% checkin an open connection after use
 -callback checkin({Info::any(), CheckingReference::any(), Owner::pid(),
   Transport::atom()}, Socket::inet:socket()) ->
   ok
   | {error, Reason :: any()}.
+
+%% pass a message to the given pool
+-callback notify(Pool::atom(), Message::any()) -> ok.
 
 -endif.


### PR DESCRIPTION
There are two issues I ran into, when creating a custom `hackney` pool.
This PR should fix those issues and make it easier for people to implement custom pools.

### 1. The `pool_handler` is not always set
**Issue:**
The client `pool_handler` is not set, when the pool handler returns `no_socket`.  
**Effect:**
The default `hackney_pool:checkin` is called in stead of the set pool.
This breaks functionality and most likely will cause a direct `gen_server` call to the custom pool pid.

### 2. Incomplete behaviour `hackney_pool_handler`
**Issue:**
The `hackney_pool_handler` behaviour is missing the `notify` function.  
**Effect:**
The `notify` function is called after socket usage, which makes the call fail.
Either `notify` should not be used or should be part of the behaviour.
This helps custom pool developers set up the right functions from the start.