### PR TITLE
fix deadlock in hackney_pool during request timeout

### DIFF
--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -1,0 +1,44 @@
+-module(hackney_pool_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include("hackney_lib.hrl").
+
+%% This seems necessary to list the tests including the generator
+dummy_test() ->
+    ?assertEqual(ok, ok).
+
+multipart_test_() ->
+    {setup, fun start/0, fun stop/1,
+      [queue_timeout()]}.
+
+start() ->
+    error_logger:tty(false),
+    {ok, _} = application:ensure_all_started(cowboy),
+    {ok, _} = application:ensure_all_started(hackney),
+    Host = '_',
+    Resource = {"/pool", pool_resource, []},
+    Dispatch = cowboy_router:compile([{Host, [Resource]}]),
+    cowboy:start_http(test_server, 10, [{port, 8123}], [{env, [{dispatch, Dispatch}]}]).
+
+stop({ok, _Pid}) ->
+    cowboy:stop_listener(test_server),
+    application:stop(cowboy),
+    application:stop(hackney),
+    error_logger:tty(true),
+    ok.
+
+queue_timeout() ->
+    fun() ->
+        URL = <<"http://localhost:8123/pool">>,
+        Headers = [],
+        Opts = [{pool, true}, {connect_timeout, 100}],
+        ok = application:set_env(hackney, max_connections, 1),
+        case hackney:request(post, URL, Headers, stream, Opts) of
+            {ok, Ref} ->
+                {error, _} = hackney:request(post, URL, Headers, stream, Opts),
+                ok = hackney:finish_send_body(Ref),
+                {ok, _Status, _Headers, Ref} = hackney:start_response(Ref),
+                ok = hackney:skip_body(Ref),
+                {ok, _} = hackney:request(post, URL, Headers, stream, Opts)
+        end
+    end.
+

--- a/test/pool_resource.erl
+++ b/test/pool_resource.erl
@@ -1,0 +1,19 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @doc Pool handler.
+-module(pool_resource).
+
+-export([init/3]).
+-export([handle/2]).
+-export([terminate/3]).
+
+init(_, Req, _Opts) ->
+	{ok, Req, undefined}.
+
+handle(Req, State) ->
+    {ok, Body, Req2} = cowboy_req:body(Req, [{length, infinity}]),
+    {ok, Req3} = cowboy_req:reply(200, [], Body, Req2),
+    {ok, Req3, State}.
+
+terminate(_Reason, _Req, _State) ->
+    ok.


### PR DESCRIPTION
This mostly resolves https://github.com/benoitc/hackney/issues/420 (and also includes https://github.com/benoitc/hackney/pull/419).

A race condition still exists, between the request timeout occurring till when the cast to `checkout_cancel` is processed.  I suspect it is really unlikely, though fortunately it is detectable so we could choose to do something about it later if this occurs.

A possible improvement would be to when the race occurs we dig around the `client` state element and reclaim the socket back into the pool?