### PR TITLE
Fix memory leak in hackney_manager.

### DIFF
--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -503,7 +503,7 @@ handle_exit(Pid, {Ref, stream}, Reason, State) ->
     [{Ref, {Owner, Pid, #request_info{pool=Pool}=Info}}] ->
       %% unlink the owner
       unlink(Owner),
-      Pids2 = dict:erase(Pid, Pids1),
+      Pids2 = dict:erase(Owner, Pids1),
       %% if anormal reason let the owner knows
       _ = case Reason of
             normal ->  ok;


### PR DESCRIPTION
I've been doing some load testing of an Elixir service we've written, that makes
a lot of HTTP requests with hackney using async responses. I noticed that after
about a million requests, the hackney_manager process ended up using about 500MB
of memory. This memory use did not go down when I turned the load testing off,
and the application was sitting totally idle.

Looking into the state of the process, it's pid dict contained about a million
entries - presumably one for every request that had been made.

After investigating, I've tracked this down to the handle_exit implementation
for stream processes.  It was not actually trying to remove the owner PID from
the dict, but was trying to remove the stream PID twice.

Fixes #441