### PR TITLE
Hackney performance improvements

### DIFF
--- a/src/hackney_app.erl
+++ b/src/hackney_app.erl
@@ -20,6 +20,8 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+  Metrics = metrics:init(hackney_util:mod_metrics()),
+  application:set_env(hackney, metrics, Metrics),
   hackney_sup:start_link().
 
 stop(_State) ->

--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -66,7 +66,7 @@ create_connection(Transport, Host, Port, Options, Dynamic)
   MaxBody = proplists:get_value(max_body, Options),
 
   %% get mod metrics
-  Engine = metrics:init(hackney_util:mod_metrics()),
+  {ok, Engine} = application:get_env(hackney, metrics),
 
   %% initial state
   InitialState = #client{mod_metrics=Engine,

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -209,7 +209,6 @@ start_link(Name, Options0) ->
   gen_server:start_link(?MODULE, [Name, Options], []).
 
 init([Name, Options]) ->
-  process_flag(priority, high),
   case lists:member({seed,1}, ssl:module_info(exports)) of
     true ->
       % Make sure that the ssl random number generator is seeded

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -474,7 +474,7 @@ add_to_queue({_Host, _Port, _Transport} = Dest, From, Ref, Queues) ->
 del_from_queue({_Host, _Port, _Transport} = Dest, Ref, Queues) ->
   case dict:find(Dest, Queues) of
     error ->
-      {Queues, 0};
+      {Queues, false};
     {ok, Q} ->
       Q2 = queue:filter(fun({_, R}) -> R =/= Ref end, Q),
       Removed = queue:len(Q) =/= queue:len(Q2),


### PR DESCRIPTION
Hackney has been responsible for taking down our site a couple of times, this fixes some of the issues:

1. Hackney's pool runs at high priority despite the fact that docs explicitly tell users not to use this flag. This causes issues when Erlang's scheduler spends too much time interacting with the pool and not enough time doing other things. We've been running without this flag for a couple months, and there's no difference in Hackney's performance. 
1. There was a case clause mismatch that was spamming our logs.
1. Hackney utilizes a metrics module that abstracts between several different metrics providers. This module is dynamically recompiled every time a new connection is created. This recompilation is incredibly expensive, requiring every process in the system to be woken up from hibernation and then send a message. The code server then needs to receive every message in order to continue. For large pools, this can take *minutes* to complete and during this time, Erlang becomes totally unresponsive. The fix is to move compilation to application start and to read an application variable to find the metrics module. 

