### PR TITLE
Fix documentation for the removed method

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This fixes zsh (and maybe other shells) escript-related bugs. Also this should s
 
 ```erlang-repl
 
-1>> hackney:start().
+1>> application:ensure_all_started(hackney).
 ok
 ```
 


### PR DESCRIPTION
hackney:start() method was removed by [this commit](https://github.com/benoitc/hackney/commit/60682e9b913d9c4fe9a8c410407b7f51b42fab8b#diff-56e36daa3cf3f5e3ed2b6cd04efcb462). It took a bit of my time to find the fix.