### PR TITLE
Fix for no case clause matching {error,{poorly_formatted_size,"AAE "}}

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -447,7 +447,7 @@ read_size(Data) ->
   case read_size(Data, [], true) of
     {ok, Line, Rest} ->
       case io_lib:fread("~16u", Line) of
-        {ok, [Size], []} ->
+        {ok, [Size], _} ->
           {ok, Size, Rest};
         _ ->
           {error, {poorly_formatted_size, Line}}


### PR DESCRIPTION
Fix for attempt to fetch failed: {:poorly_formatted_size}. Reference issue: https://github.com/benoitc/hackney/issues/477

` {ok, [Size], []}` was replaced with ` {ok, [Size], _}` here because the third parameter of the output is the list of remaining characters, i.e. the ' ' (ref http://erlang.org/doc/man/io_lib.html#fread-2). By specifying `[]` the code assumed there would be no extra characters in the line (which isn't the case for the web pages in the issue)