### PR TITLE
Trivial: Replace no-break space (U+00A0) with ASCII in source files.

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -40,7 +40,7 @@
 -include("hackney_internal.hrl").
 
 
--type url() :: #hackney_url{} | binary().
+-type url() :: #hackney_url{} | binary().
 -export_type([url/0]).
 
 -opaque client() :: #client{}.

--- a/src/hackney_headers_new.erl
+++ b/src/hackney_headers_new.erl
@@ -31,8 +31,8 @@
 
 
 -type headers() ::term().
--type key() :: binary() | string().
--type value() :: binary() | {binary() | list({binary(), binary()} | binary())}.
+-type key() :: binary() | string().
+-type value() :: binary() | {binary() | list({binary(), binary()} | binary())}.
 -type headers_list() :: [{key(), value()}].
 
 -export_types([headers/0, key/0, value/0]).
@@ -64,7 +64,7 @@ append(Key, Value, {N, Headers}) ->
   {N + 1, dict:append(KL, {N, Key, Value}, Headers)}.
 
 %% @doc replace the content of the header field with the value or the list of values.
--spec store(key(), value() | [value()], headers()) -> headers().
+-spec store(key(), value() | [value()], headers()) -> headers().
 store(Key, Values, {N, Headers}) when is_list(Values) ->
   KL = ?kl(Key),
   lists:foldl(
@@ -125,7 +125,7 @@ lookup(Key, {_, Headers}) ->
 get_value(Key, Headers) -> get_value(Key, Headers, undefined).
 
 %% @doc get the first value of an headers or return the default
--spec get_value(key(), headers(), any()) -> value() | any().
+-spec get_value(key(), headers(), any()) -> value() | any().
 get_value(Key, Headers, Default) ->
   case lookup(Key, Headers) of
     [] -> Default;

--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -499,7 +499,7 @@ handle_owner_exit(Pid, Refs, Reason, State) ->
   NewState = clean_requests(Refs, Pid, Reason, PoolHandler, State#mstate{pids=Pids1}),
   {noreply, NewState}.
 
-clean_requests([Ref | Rest], Pid, Reason, PoolHandler, State) ->
+clean_requests([Ref | Rest], Pid, Reason, PoolHandler, State) ->
   case ets:lookup(?REFS, Ref) of
     [] ->
       %% ref already removed just return

--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -195,7 +195,7 @@ stream_body_recv(Buffer, Client=#client{version=Version,
     -> {headers, list(), #client{}} | {body, binary(), #client{}}
   | {eof|end_of_part|mp_mixed|mp_mixed_eof, #client{}}.
 stream_multipart(Client=#client{headers=Headers, body_state=waiting, clen=Length}) ->
-  CType = hackney_headers_new:get_value(<<"content-type">>, Headers),
+  CType = hackney_headers_new:get_value(<<"content-type">>, Headers),
   {<<"multipart">>, _, Params} = hackney_headers_new:parse_content_type(CType),
   {_, Boundary} = lists:keyfind(<<"boundary">>, 1, Params),
   Parser = hackney_multipart:parser(Boundary),
@@ -310,9 +310,9 @@ read_body(MaxLength, Client, Acc) when MaxLength > byte_size(Acc) ->
       read_body(MaxLength, Client2, << Acc/binary, Data/binary >>);
     {done, Client2} ->
       {ok, Acc, Client2};
-    {error, Reason}=Error ->
+    {error, Reason}=Error ->
       case Reason of
-        {closed, Bin} when is_binary(Bin) ->
+        {closed, Bin} when is_binary(Bin) ->
           {error, {closed, << Acc/binary, Bin/binary >>}};
         _ ->
           Error

--- a/src/hackney_trace.erl
+++ b/src/hackney_trace.erl
@@ -59,7 +59,7 @@ disable() ->
 
 
 %% @doc change the trace level when tracing has already started.
--spec set_level(trace_level()) -> ok | {error, term()}.
+-spec set_level(trace_level()) -> ok | {error, term()}.
 set_level(Level) ->
   Pat = make_pattern(?MODULE, Level),
   change_pattern(Pat).


### PR DESCRIPTION
This is cosmetic, but there are a few instances of nbsp in sources; they were probably added by mistake?

These characters make my Erlide refuse to open these files with an error.