### PR TITLE
Allow trailing spaces at the end of chunk sizes

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -465,6 +465,9 @@ read_size(<<"\r\n", Rest/binary>>, Acc, _) ->
 read_size(<<$;, Rest/binary>>, Acc, _) ->
   read_size(Rest, Acc, false);
 
+read_size(<<$\s, Rest/binary>>, Acc, _) ->
+  read_size(Rest, Acc, false);
+
 read_size(<<C, Rest/binary>>, Acc, AddToAcc) ->
   case AddToAcc of
     true ->


### PR DESCRIPTION
For example, `3 \r\nfoo` currently gets rejected due to the space before CRLF. This change will accept it. This is, as far as I can tell, accepted across browsers, API testing programs (e.g. Insomnia) etc. I'm not really sure whether it's strictly acceptable according to the HTTP spec (a strict reading suggests not, but support is so universal it might be).

There's absolutely no reason for these trailing spaces, but I'm working against an API that's unlikely to change and which ends up including them. Figured I'd fix it for myself at least and see whether this is acceptable for this as well :)