### PR TITLE
Fix accessing HTTPS sites with an IPv4 address

### DIFF
--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -50,7 +50,7 @@ messages(_) -> {ssl, ssl_closed, ssl_error}.
 %% string and either returns such tuple, or the string if it's impossible to
 %% parse.
 parse_address(Host) when is_list(Host) ->
-  case inet:parse_address() of
+  case inet:parse_address(Host) of
     {ok, Address} -> Address;
     {error, _} -> Host
   end.

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -49,6 +49,13 @@ connect(Host, Port, Opts) ->
 
 connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
                                         (Timeout =:= infinity orelse is_integer(Timeout)) ->
+  Host1 = try
+            Parts = string:split(Host, ".", all),
+            4 = length(Parts),
+            list_to_tuple(lists:map(fun list_to_integer/1, Parts))
+          catch
+            _:_ -> Host
+          end,
   BaseOpts = [binary, {active, false}, {packet, raw},
     {secure_renegotiate, true},
     {reuse_sessions, true},
@@ -58,7 +65,7 @@ connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
   Opts1 = hackney_util:merge_opts(BaseOpts, Opts),
   
   %% connect
-  ssl:connect(Host, Port, Opts1, Timeout).
+  ssl:connect(Host1, Port, Opts1, Timeout).
 
 
 ciphers() ->

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -46,8 +46,8 @@ messages(_) -> {ssl, ssl_closed, ssl_error}.
 
 %% @doc The ssl:connect/4 (and related) doesn't work with textual representation
 %% of IP addresses. It accepts either a string with a DNS-resolvable name or a
-%% tuple with a tag and parts of the IP as numbers. This function returns a tuple
-%% like that, or the original string if it's impossible to parse as an IP.
+%% tuple and parts of the IP as numbers. This function returns a tuple like
+%% that, or the original string if it's impossible to parse as an IP.
 parse_address(Host) when is_list(Host) ->
   case inet:parse_address() of
     {ok, Address} -> Address;

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -46,8 +46,9 @@ messages(_) -> {ssl, ssl_closed, ssl_error}.
 
 %% @doc The ssl:connect/4 (and related) doesn't work with textual representation
 %% of IP addresses. It accepts either a string with a DNS-resolvable name or a
-%% tuple and parts of the IP as numbers. This function returns a tuple like
-%% that, or the original string if it's impossible to parse as an IP.
+%% tuple with parts of an IP as numbers. This function attempts to parse given
+%% string and either returns such tuple, or the string if it's impossible to
+%% parse.
 parse_address(Host) when is_list(Host) ->
   case inet:parse_address() of
     {ok, Address} -> Address;


### PR DESCRIPTION
Hi, I was writing an internal monitoring tool and found that I need to access URLs in the form of `https://123.123.123.123/something/` - that is, URLs with HTTPS protocol and numeric IP in the host part. Unfortunately, when I tried issuing such requests I discovered that Hackney doesn't allow this case. (Actually, I was writing in Elixir with HTTPoison, which in turn uses Hackney.)

After some time debugging I discovered that Erlang's ssl application supports requests to IP addresses only if they are presented as four-tuples of ints, not as strings.

I created a quick fix for this which works for me - just before the `ssl:connect` I split the Host string on dots and check if they can be interpreted as an IP address. I'm not sure if it's any good, it's fine if it's not, but then I think it would be worth it to at least state in the README that HTTPS+IP doesn't work.