### PR TITLE
fix terminate_async_response

### DIFF
--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -540,32 +540,20 @@ clean_requests([], _Pid, _Reason, _PoolHandler, State) ->
 monitor_child(Pid) ->
   erlang:monitor(process, Pid),
   unlink(Pid),
-
   receive
-    {'EXIT', Pid, Reason} ->
-      receive
-        {'DOWN', _, process, Pid, normal} ->
-          ok;
-        {'DOWN', _, process, Pid, noproc} ->
-          ok;
-        {'DOWN', _, process, Pid, _} ->
-          {error, Reason}
-      end
+    {'EXIT', Pid, _} ->
+      true
   after 0 ->
-          ok
+    true
   end.
 
-terminate_async_response(Stream) ->
-  terminate_async_response(Stream, shutdown).
+terminate_async_response(StreamPid) ->
+  terminate_async_response(StreamPid, shutdown).
 
-terminate_async_response(Stream, Reason) ->
-  case monitor_child(Stream) of
-    ok ->
-      exit(Stream, Reason),
-      wait_async_response(Stream);
-    Error ->
-      Error
-  end.
+terminate_async_response(StreamPid, Reason) ->
+  _ = monitor_child(StreamPid),
+  exit(StreamPid, Reason),
+  wait_async_response(StreamPid).
 
 wait_async_response(Stream) ->
   receive

--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -164,8 +164,6 @@ stream_body1(Error, _Client) ->
 -spec stream_body_recv(binary(), #client{})
     -> {ok, binary(), #client{}} | {error, term()}.
 stream_body_recv(Buffer, Client=#client{version=Version, clen=CLen}) ->
-  io:format("receive ~p~n", [Buffer]),
-
   case recv(Client) of
     {ok, Data} ->
       stream_body(Data, Client);


### PR DESCRIPTION
following observations of @obmarg delay the monitoring of the stream process in wait_async_response instead of doing it in monitor_child.

fix #498