### PR TITLE
test erlang 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: erlang
 otp_release:
-  - 20.2
+  - 21.0.2
+  - 20.3
   - 19.3
 
 env:

--- a/rebar.config
+++ b/rebar.config
@@ -17,10 +17,9 @@
 {deps, [
         {idna, "5.1.2"},
         {mimerl, "1.0.2"},
-        {certifi, "2.3.1"},
+        {certifi, {git, "https://github.com/certifi/erlang-certifi", {ref, "26cb0f3"}}}, 
         {metrics, "1.0.1"},
-        {ssl_verify_fun, "1.1.4"},
-        {parse_trans, "3.3.0"}
+        {ssl_verify_fun, "1.1.4"}
        ]}.
 
 {profiles, [{docs, [{deps,

--- a/rebar.config
+++ b/rebar.config
@@ -19,14 +19,15 @@
         {mimerl, "1.0.2"},
         {certifi, "2.3.1"},
         {metrics, "1.0.1"},
-        {ssl_verify_fun, "1.1.1"}
+        {ssl_verify_fun, "1.1.4"},
+        {parse_trans, "3.3.0"}
        ]}.
 
 {profiles, [{docs, [{deps,
                      [
                       {edown,
                        {git, "https://github.com/uwiger/edown.git",
-                        {tag, "0.8"}}}
+                        {tag, "0.8.1"}}}
                      ]},
 
               {edoc_opts, [{doclet, edown_doclet},
@@ -35,7 +36,7 @@
                            {top_level_readme,
                             {"./README.md", "http://github.com/benoitc/hackney"}}]}]},
              {test, [
-               {deps, [{cowboy, "1.0.4"}, {jsone, "1.4.3"}]}
+               {deps, [{cowboy, "1.0.4"}, {jsone, "1.4.6"}]}
              ]}
            ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,8 +3,8 @@
  {<<"idna">>,{pkg,<<"idna">>,<<"5.1.2">>},0},
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},0},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.2">>},0},
- {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.2.0">>},1},
- {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},0},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.4">>},0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.3.1">>},1}]}.
 [
 {pkg_hash,[
@@ -12,7 +12,7 @@
  {<<"idna">>, <<"E21CB58A09F0228A9E0B95EAA1217F1BCFC31A1AAA6E1FDF2F53A33F7DBD9494">>},
  {<<"metrics">>, <<"25F094DEA2CDA98213CECC3AEFF09E940299D950904393B2A29D191C346A8486">>},
  {<<"mimerl">>, <<"993F9B0E084083405ED8252B99460C4F0563E41729AB42D9074FD5E52439BE88">>},
- {<<"parse_trans">>, <<"2ADFA4DAF80C14DC36F522CF190EB5C4EE3E28008FC6394397C16F62A26258C2">>},
- {<<"ssl_verify_fun">>, <<"28A4D65B7F59893BC2C7DE786DEC1E1555BD742D336043FE644AE956C3497FBE">>},
+ {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
+ {<<"ssl_verify_fun">>, <<"F0EAFFF810D2041E93F915EF59899C923F4568F4585904D010387ED74988E77B">>},
  {<<"unicode_util_compat">>, <<"A1F612A7B512638634A603C8F401892AFBF99B8CE93A45041F8AACA99CADB85E">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,14 +1,16 @@
 {"1.1.0",
-[{<<"certifi">>,{pkg,<<"certifi">>,<<"2.3.1">>},0},
+[{<<"certifi">>,
+  {git,"https://github.com/certifi/erlang-certifi",
+       {ref,"26cb0f341151b67dc676ce97cd7e42b4bb99d31e"}},
+  0},
  {<<"idna">>,{pkg,<<"idna">>,<<"5.1.2">>},0},
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},0},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.2">>},0},
- {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.4">>},0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.3.1">>},1}]}.
 [
 {pkg_hash,[
- {<<"certifi">>, <<"D0F424232390BF47D82DA8478022301C561CF6445B5B5FB6A84D49A9E76D2639">>},
  {<<"idna">>, <<"E21CB58A09F0228A9E0B95EAA1217F1BCFC31A1AAA6E1FDF2F53A33F7DBD9494">>},
  {<<"metrics">>, <<"25F094DEA2CDA98213CECC3AEFF09E940299D950904393B2A29D191C346A8486">>},
  {<<"mimerl">>, <<"993F9B0E084083405ED8252B99460C4F0563E41729AB42D9074FD5E52439BE88">>},

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -43,7 +43,7 @@
 -type url() :: #hackney_url{} | binary().
 -export_type([url/0]).
 
--opaque client() :: #client{}.
+-type client() :: #client{}.
 -export_type([client/0]).
 
 -type client_ref() :: term().

--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -60,7 +60,7 @@
 -include("hackney_lib.hrl").
 
 
--opaque parser() :: #hparser{}.
+-type parser() :: #hparser{}.
 -export_type([parser/0]).
 
 -type http_version() :: {integer(), integer()}.
@@ -74,10 +74,13 @@
 
 -type parser_result() ::
 {response, http_version(), status(), http_reason(), parser()}
-| {request, http_version(), http_method(), uri(), parser()}
+| {request, http_method(), uri(), http_version(), parser()}
 | {more, parser()}
 | body_result()
-| {error, term()}.
+| {error, term()}
+| done
+| {headers_complete, parser()}
+| {header, {binary(), binary()}, parser()}.
 
 -type parser_option() :: request | response | auto
 | {max_empty_lines, integer()}
@@ -350,7 +353,7 @@ parse_body(St) ->
 
 
 -spec transfer_decode(binary(), #hparser{})
-    -> {ok, binary(), #hparser{}} | {error, atom()}.
+    -> {ok, binary(), #hparser{}} | {error, atom()} | {done, binary()}.
 transfer_decode(Data, St=#hparser{
   body_state={stream, TransferDecode,
     TransferState, ContentDecode},

--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -269,7 +269,7 @@ body(Client) ->
 body(MaxLength, Client) ->
   read_body(MaxLength, Client, <<>>).
 
--spec skip_body(#client{}) -> {ok, #client{}} | {error, atom()}.
+-spec skip_body(#client{}) -> {ok, #client{}} | {error, atom()} | {skip, #client{}}.
 skip_body(Client) ->
   case stream_body(Client) of
     {ok, _, Client2} -> skip_body(Client2);


### PR DESCRIPTION
The erlang-certifi needs parse_trans 3.3.0 for dep, I also make a pr to it, see certifi/erlang-certifi#31.
If that pr merged and a new tag is made, I will modify this pr.