### PR TITLE
Fix doc for checkout_timeout default

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -240,7 +240,8 @@ request(Method, URL, Headers, Body) ->
 %%          <li>`insecure': to perform "insecure" SSL connections and
 %%          transfers without checking the certificate</li>
 %%          <li>`{checkout_timeout, infinity | integer()}': timeout used when
-%%          checking out a socket from the pool, in milliseconds. Default is 8000</li>
+%%          checking out a socket from the pool, in milliseconds.
+%%          By default is equal to connect_timeout</li>
 %%          <li>`{connect_timeout, infinity | integer()}': timeout used when
 %%          establishing a connection, in milliseconds. Default is 8000</li>
 %%          <li>`{recv_timeout, infinity | integer()}': timeout used when


### PR DESCRIPTION
Hello!
Current doc is a bit misleading because if you have custom `connect_timeout` when default `checkout_timeout` won't be equal to 8000.