### PR TITLE
Replace cacerts usage by cacertfile

### DIFF
--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -323,7 +323,6 @@ ssl_opts(Host, Options) ->
 
 ssl_opts_1(Host, Options) ->
   Insecure =  proplists:get_value(insecure, Options, false),
-  CACerts = certifi:cacerts(),
   case Insecure of
     true ->
       [{verify, verify_none}];
@@ -334,7 +333,7 @@ ssl_opts_1(Host, Options) ->
        },
       [{verify, verify_peer},
        {depth, 99},
-       {cacerts, CACerts},
+       {cacertfile, certifi:cacertfile()},
        {partial_chain, fun partial_chain/1},
        {verify_fun, VerifyFun}]
   end.


### PR DESCRIPTION
Hello!
Finally I found a little bit of time to make this PR after https://github.com/certifi/erlang-certifi/issues/19 have been merged.
It gives quite big performance improvements and it's cool that it will work out of the box for everyone :-)