### PR TITLE
fixed pathencode to support '(' ')' characters

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "simple HTTP client"},
-    {vsn, "1.15.1"},
+    {vsn, "1.15.0"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "simple HTTP client"},
-    {vsn, "1.15.0"},
+    {vsn, "1.15.1"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -414,7 +414,7 @@ partial_pathencode(<<C, Rest/binary>> = Bin, Acc) ->
   if	C >= $0, C =< $9 -> partial_pathencode(Rest, <<Acc/binary, C>>);
     C >= $A, C =< $Z -> partial_pathencode(Rest, <<Acc/binary, C>>);
     C >= $a, C =< $z -> partial_pathencode(Rest, <<Acc/binary, C>>);
-    C =:= $;; C =:= $=; C =:= $,; C =:= $:; C =:= $@ ->
+    C =:= $;; C =:= $=; C =:= $,; C =:= $:; C =:= $@; C =:= $(; C =:= $) ->
       partial_pathencode(Rest, <<Acc/binary, C>>);
     C =:= $.; C =:= $-; C =:= $+; C =:= $~; C =:= $_ ->
       partial_pathencode(Rest, <<Acc/binary, C>>);

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -288,7 +288,9 @@ pathencode_test_() ->
             {<<"/path1/path2%2fa%2fb">>, <<"/path1/path2%2fa%2fb">>},
             {<<"/path1/path2%2test">>, <<"/path1/path2%252test">>},
             {<<"/id/name:107/name2;p=1,3">>, <<"/id/name:107/name2;p=1,3">>},
-            {<<"/@foobar">>, <<"/@foobar">>}
+            {<<"/@foobar">>, <<"/@foobar">>},
+            {<<"/500x720/filters:quality(75):format(jpg)/spree/product/s/p/spree2018september12picslgzh0650.jpg">>,
+             <<"/500x720/filters:quality(75):format(jpg)/spree/product/s/p/spree2018september12picslgzh0650.jpg">>}
             ],
     [{V, fun() -> R = hackney_url:pathencode(V) end} || {V, R} <- Tests].
 


### PR DESCRIPTION
Related to  #550 

After checking the [RFC ](https://tools.ietf.org/html/rfc3986#section-2.2) section 2.2, Reserved Characters, sub-delims, it seems that url path with '(' ')' characters is valid and should not be encoded.
I would like to do the same for the other characters as well, and do a small refactor that will reflect the RFC.
What do you think?

Cheers
 
