### PR TITLE
don't try to encode to idna an full ascii name.

### DIFF
--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -38,14 +38,10 @@ connect(Transport, Host, Port, Options, Dynamic) ->
     {dynamic, Dynamic}]),
 
   Host2 = case Transport of
-            hackney_local_tcp -> Host;
+            hackney_local_tcp ->
+              Host;
             _ ->
-              case inet:parse_address(Host) of
-                {ok, _} ->
-                  Host;
-                _ ->
-                  idna:utf8_to_ascii(Host)
-              end
+              hackney_url:idnconvert_hostname(Host)
           end,
 
   case create_connection(Transport, Host2, Port, Options, Dynamic) of

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -23,6 +23,8 @@
   pathencode/1,
   normalize/1, normalize/2]).
 
+-export([idnconvert_hostname/1]).
+
 -include("hackney_lib.hrl").
 
 -type qs_vals() :: [{binary(), binary() | true}].
@@ -116,6 +118,17 @@ transport_scheme(hackney_ssl) ->
   https;
 transport_scheme(hackney_local_tcp) ->
   http_unix.
+
+is_ascii(Host) ->
+  lists:all(fun(C) -> idna_ucs:is_ascii(C) end, Host).
+
+idnconvert_hostname(Host) ->
+  case is_ascii(Host) of
+    true ->
+      Host;
+    false ->
+      idna:utf8_to_ascii(Host)
+  end.
 
 unparse_url(#hackney_url{}=Url) ->
   #hackney_url{scheme = Scheme,

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -91,14 +91,14 @@ normalize(#hackney_url{}=Url, Fun) when is_function(Fun, 1) ->
                      {ok, {_, _, _, _, _, _, _, _}} ->
                        {Host0, Netloc0};
                      _ ->
-                       Host1 = unicode:characters_to_list(
+                       Host1 = binary_to_list(
                                  urldecode(unicode:characters_to_binary(Host0))
                                 ),
 
                        %% encode domain if needed
                        Host2 = case Scheme of
                                  http_unix -> Host1;
-                                 _ -> idna:to_ascii(Host1)
+                                 _ -> idnconvert_hostname(Host1)
                                end,
                        Netloc1 = case {Scheme, Port} of
                                    {http, 80} -> list_to_binary(Host2);


### PR DESCRIPTION
some local hostname contains an underscore or other things that are
tolerated by clients like curl. Do the same as curl then and just try to
encode the domain name if it contains some unicode characters.

fix #557