### PR TITLE
correct the spec for stop_async/1

### DIFF
--- a/doc/hackney.md
+++ b/doc/hackney.md
@@ -588,7 +588,7 @@ and headers of the response. and return
 ### stop_async/1 ###
 
 <pre><code>
-stop_async(Ref::<a href="#type-client_ref">client_ref()</a>) -&gt; ok | {error, req_not_found} | {error, term()}
+stop_async(Ref::<a href="#type-client_ref">client_ref()</a>) -&gt; {ok, <a href="#type-client_ref">client_ref()</a>} | {error, req_not_found} | {error, term()}
 </code></pre>
 <br />
 

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -554,7 +554,7 @@ resume_stream(Ref) ->
                                                end).
 
 %% @doc stop to receive asynchronously.
--spec stop_async(client_ref()) -> ok | {error, req_not_found} | {error, term()}.
+-spec stop_async(client_ref()) -> {ok, client_ref()} | {error, req_not_found} | {error, term()}.
 stop_async(Ref) ->
   hackney_manager:stop_async_response(Ref).
 


### PR DESCRIPTION
Hello! 

The spec for `stop_async` seems wrong. The function returns `{ok, client_ref()}` on success not `ok`.
This seems to be confirmed by `examples/test_async_once2.erl`.

```erlang
{ok, Ref} = hackney:stop_async(Ref),
```

Regards,
Radu

P.S. Thanks for providing this library!
