### PR TITLE
store/3 creates invalid dict when called with list of Values

### DIFF
--- a/src/hackney_headers_new.erl
+++ b/src/hackney_headers_new.erl
@@ -69,7 +69,7 @@ store(Key, Values, {N, Headers}) when is_list(Values) ->
   KL = ?kl(Key),
   lists:foldl(
     fun(V, {I, H}) ->
-      {I + 1, dict:append(KL, [{I, Key, V}], H)}
+      {I + 1, dict:append(KL, {I, Key, V}, H)}
     end,
     {N, dict:store(KL, [], Headers)},
     Values

--- a/test/hackney_headers_new_test.erl
+++ b/test/hackney_headers_new_test.erl
@@ -39,12 +39,16 @@ key_type_test() ->
 store_test() ->
   A = [{<<"Foo">>, <<"Bar">>}],
   B = [{<<"Bar">>, <<"Baz">>}],
+  C = [{<<"Baz">>, <<"Bar">>}],
   Ha = hackney_headers_new:from_list(A),
   Hb = hackney_headers_new:from_list(B),
-  
+  Hc = hackney_headers_new:from_list(C),
+
   Expected1 = [{<<"Foo">>, <<"Bar">>}, {<<"Bar">>, <<"Baz">>}],
   Expected2 = [{<<"Bar">>, <<"Baz">>}, {<<"Foo">>, <<"Bar">>}],
-  
+  Expected3 = [{<<"Baz">>, <<"Bar">>},
+               {<<"Foo">>, <<"Bar">>},
+               {<<"Foo">>, <<"Baz">>}],  
   
   ?assertEqual(
     Expected1,
@@ -53,6 +57,12 @@ store_test() ->
   ?assertEqual(
     Expected2,
     hackney_headers_new:to_list(hackney_headers_new:store(<<"Foo">>, <<"Bar">>, Hb))
+  ),
+  ?assertEqual(
+    Expected3,
+    hackney_headers_new:to_list(hackney_headers_new:store(<<"Foo">>,
+                                                          [<<"Bar">>, <<"Baz">>],
+                                                          Hc))
   ).
 
 merge_test() ->


### PR DESCRIPTION
store/3 creates invalid dict when called with list of Values, causing function_clause in to_list