### PR TITLE
Fixes test run example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Running the tests:
 
 ```
 $ gunicorn --daemon --pid httpbin.pid httpbin:app
-$ make test
+$ rebar3 eunit
 $ kill `cat httpbin.pid`
 ```
 
@@ -556,4 +556,3 @@ $ kill `cat httpbin.pid`
 <tr><td><a href="http://github.com/benoitc/hackney/blob/master/doc/hackney_trace.md" class="module">hackney_trace</a></td></tr>
 <tr><td><a href="http://github.com/benoitc/hackney/blob/master/doc/hackney_url.md" class="module">hackney_url</a></td></tr>
 <tr><td><a href="http://github.com/benoitc/hackney/blob/master/doc/hackney_util.md" class="module">hackney_util</a></td></tr></table>
-


### PR DESCRIPTION
Originally the command for running the tests was `make test`. There is no `make
test` task, but there is `rebar3 eunit` which is mentioned higher in the README.
I tested the tests replacing `make test` with `rebar3 eunit` and everything ran
so I assume this is the correct way of running the tests.

Amos King @adkron <amos@binarynoggin.com>