### PR TITLE
Fix hackeny.POOL.queue_count metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ been started.
 |hackney.POOLNAME.no_socket    |counter  | Count of new connections                                             |
 |hackney.POOLNAME.in_use_count |histogram| How many connections from the pool are used                          |
 |hackney.POOLNAME.free_count   |counter  | Number of free sockets in the pool                                   |
-|hackney.POOLNAME.queue_counter|histogram| queued clients                                                       |
+|hackney.POOLNAME.queue_count  |histogram| queued clients                                                       |
 
 ## Contribute
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -485,7 +485,7 @@ been started.
 |hackney.POOLNAME.no_socket    |counter  | Count of new connections                                             |
 |hackney.POOLNAME.in_use_count |histogram| How many connections from the pool are used                          |
 |hackney.POOLNAME.free_count   |counter  | Number of free sockets in the pool                                   |
-|hackney.POOLNAME.queue_counter|histogram| queued clients                                                       |
+|hackney.POOLNAME.queue_count  |histogram| queued clients                                                       |
 
 ## Contribute
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -482,7 +482,7 @@ been started.
 |hackney.POOLNAME.no_socket    |counter  | Count of new connections                                             |
 |hackney.POOLNAME.in_use_count |histogram| How many connections from the pool are used                          |
 |hackney.POOLNAME.free_count   |counter  | Number of free sockets in the pool                                   |
-|hackney.POOLNAME.queue_counter|histogram| queued clients                                                       |
+|hackney.POOLNAME.queue_count  |histogram| queued clients                                                       |
 
 ## Contribute
 

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -602,7 +602,7 @@ init_metrics(PoolName) ->
   _ = metrics:new(Engine, counter, [hackney_pool, PoolName, no_socket]),
   _ = metrics:new(Engine, histogram, [hackney_pool, PoolName, in_use_count]),
   _ = metrics:new(Engine, histogram, [hackney_pool, PoolName, free_count]),
-  _ = metrics:new(Engine, histogram, [hackney_pool, PoolName, queue_counter]),
+  _ = metrics:new(Engine, histogram, [hackney_pool, PoolName, queue_count]),
   Engine.
 
 delete_metrics(Engine, PoolName) ->
@@ -610,7 +610,7 @@ delete_metrics(Engine, PoolName) ->
   _ = metrics:delete(Engine, [hackney_pool, PoolName, no_socket]),
   _ = metrics:delete(Engine, [hackney_pool, PoolName, in_use_count]),
   _ = metrics:delete(Engine, [hackney_pool, PoolName, free_count]),
-  _ = metrics:delete(Engine, [hackney_pool, PoolName, queue_counter]),
+  _ = metrics:delete(Engine, [hackney_pool, PoolName, queue_count]),
   ok.
 
 


### PR DESCRIPTION
It looks like the code was actually populating metrics under the `queue_count` name, but declaring the histogram as `queue_counter`. I didn't actually test that this fixes it, but wanted to get a PR opened to see whether this is the name to use or not. It seems like this would be more consistent with the other metric names.