### PR TITLE
Fix error caused by `honor_cipher_order`, CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: erlang
 otp_release:
+  - 22.0
   - 21.0.2
   - 20.3
-  - 20.2
   - 19.3
 
 env:

--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,7 @@
                            {top_level_readme,
                             {"./README.md", "http://github.com/benoitc/hackney"}}]}]},
              {test, [
-               {deps, [{cowboy, "1.0.4"}, {jsone, "1.4.7"}]}
+               {deps, [{cowboy, "1.1.2"}, {jsone, "1.4.7"}]}
              ]}
            ]}.
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -23,7 +23,7 @@ Rebar2Deps0 = [{idna, ".*",
 
 Rebar2Deps = case os:getenv("TEST") of
                  "1" -> [{cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git",
-                                         {tag, "1.0.4"}}},
+                                         {tag, "1.1.2"}}},
                          {jsone, ".*", {git, "https://github.com/sile/jsone.git",
                                         {tag, "1.4.7"}}} | Rebar2Deps0];
                  false ->

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -65,7 +65,6 @@ connect(Host, Port, Opts, Timeout) when is_list(Host), is_integer(Port),
   BaseOpts = [binary, {active, false}, {packet, raw},
     {secure_renegotiate, true},
     {reuse_sessions, true},
-    {honor_cipher_order, true},
     {versions,['tlsv1.2', 'tlsv1.1', tlsv1, sslv3]},
     {ciphers, ciphers()}],
   Opts1 = hackney_util:merge_opts(BaseOpts, Opts),
@@ -126,7 +125,7 @@ close(Socket) ->
 
 %% @doc Immediately close a socket in one or two directions.
 %% @see ssl:shutdown/2
--spec shutdown(ssl:socket(), read | write | read_write) -> ok.
+-spec shutdown(ssl:sslsocket(), read | write | read_write) -> ok | {error, any()}.
 shutdown(Socket, How) ->
   ssl:shutdown(Socket, How).
 


### PR DESCRIPTION
OTP-22.1 (commit `124da8950c`) introduced `assert_role/4` into `:ssl`, which throws an error when `:ssl.connect` is called with the `honor_cipher_order` option defined. The error returned is `{:error, {:option, :server_only, :honor_cipher_order}}`.

With OTP-22.1, a dialyzer warning also appears:

```
    129: Invalid type specification for function
    hackney_ssl:shutdown/2. The success typing is
    ( { 'sslsocket',
         _,
         nonempty_maybe_improper_list()
      | {'dtls' | port(), _}
      },
      'read' | 'read_write' | 'write'
    ) -> 'ok' | {'error',_}
```

Prior to the above, CI errors began to appear as a result of
cowboy-1.0.4 download failures. Using cowboy-1.1.2 fixes
this.

* remove `honor_cipher_order` option in `connect/4`
* add OTP-22.0 to .travis.yml
* drop OTP-20.2 from .travis.yml (no longer available)
* fix invalid type spec for `shutdown/2`
* require cowboy-1.1.2