### PR TITLE
Clarify what recv_timeout means again

### DIFF
--- a/doc/hackney.md
+++ b/doc/hackney.md
@@ -362,7 +362,7 @@ By default is equal to connect_timeout
 establishing a connection, in milliseconds. Default is 8000
 
 * `{recv_timeout, infinity | integer()}`: timeout used when
-receiving a connection. Default is 5000
+receiving data over a connection. Default is 5000
 
 
 <blockquote>Note: if the response is async, only

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -245,7 +245,7 @@ request(Method, URL, Headers, Body) ->
 %%          <li>`{connect_timeout, infinity | integer()}': timeout used when
 %%          establishing a connection, in milliseconds. Default is 8000</li>
 %%          <li>`{recv_timeout, infinity | integer()}': timeout used when
-%%          receiving a connection. Default is 5000</li>
+%%          receiving data over a connection. Default is 5000</li>
 %%      </ul>
 %%
 %%      <blockquote>Note: if the response is async, only


### PR DESCRIPTION
The previous pull request #555 looks unintentionally reverted by a sort of documentation generation in https://github.com/benoitc/hackney/commit/179c0d69589f0d3e3e35c67d457f0ca117a4cef3 .