### PR TITLE
Ignore leading newlines in response

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -168,7 +168,7 @@ parse_first_line(Buffer, St=#hparser{type=Type,
       {error, bad_request};
     1 ->
       << _:16, Rest/binary >> = Buffer,
-      parse_first_line(Rest, St, Empty + 1);
+      parse_first_line(Rest, St#hparser{buffer=Rest}, Empty + 1);
     _ when Type =:= auto ->
       case parse_request_line(St) of
         {request, _Method, _URI, _Version, _NState} = Req -> Req;

--- a/test/hackney_http_tests.erl
+++ b/test/hackney_http_tests.erl
@@ -32,3 +32,15 @@ parse_response_header_with_continuation_line_test() ->
   {header, Header1, ST4} = hackney_http:execute(ST3),
   ?assertEqual({<<"Other-Header">>, <<"test">>}, Header1),
 	{headers_complete, _ST5} = hackney_http:execute(ST4).
+
+parse_response_correct_200_leading_newlines_test() ->
+	Response = <<"\r\nHTTP/1.1 200 OK\r\n\r\n">>,
+	St = #hparser{},
+	{response, _Version, StatusInt, Reason, _NState} = hackney_http:execute(St, Response),
+	?assertEqual(StatusInt, 200),
+	?assertEqual(Reason, <<"OK">>).
+
+parse_response_error_too_many_newlines_test() ->
+	Response = <<"\r\nHTTP/1.1 200 OK\r\n\r\n">>,
+	St = #hparser{max_empty_lines = 0},
+	{error, bad_request} = hackney_http:execute(St, Response).

--- a/test/hackney_http_tests.erl
+++ b/test/hackney_http_tests.erl
@@ -44,3 +44,24 @@ parse_response_error_too_many_newlines_test() ->
 	Response = <<"\r\nHTTP/1.1 200 OK\r\n\r\n">>,
 	St = #hparser{max_empty_lines = 0},
 	{error, bad_request} = hackney_http:execute(St, Response).
+
+parse_chunked_response_crlf_test() ->
+	P0 = hackney_http:parser([response]),
+	{_, _, _, _, P1} = hackney_http:execute(P0, <<"HTTP/1.1 200 OK\r\n">>),
+	{_, _, P2} = hackney_http:execute(P1, <<"Transfer-Encoding: chunked\r\n">>),
+	{_, P3} = hackney_http:execute(P2, <<"\r\n">>),
+
+	?assertEqual({done, <<>>}, hackney_http:execute(P3, <<"0\r\n\r\n">>)),
+	?assertEqual({done, <<"a">>}, hackney_http:execute(P3, <<"0\r\n\r\na">>)),
+	{more, P4_1} = hackney_http:execute(P3, <<"0\r\n">>),
+	?assertEqual({done, <<>>}, hackney_http:execute(P4_1, <<"\r\n">>)),
+	{more, P4_2} = hackney_http:execute(P3, <<"0\r\n\r">>),
+	?assertEqual({done, <<>>}, hackney_http:execute(P4_2, <<"\n">>)).
+
+parse_chunked_response_trailers_test() ->
+	P0 = hackney_http:parser([response]),
+	{_, _, _, _, P1} = hackney_http:execute(P0, <<"HTTP/1.1 200 OK\r\n">>),
+	{_, _, P2} = hackney_http:execute(P1, <<"Transfer-Encoding: chunked\r\n">>),
+	{_, P3} = hackney_http:execute(P2, <<"\r\n">>),
+	{more, P4} = hackney_http:execute(P3, <<"0\r\nFoo: ">>),
+	?assertEqual({done, <<>>}, hackney_http:execute(P4, <<"Bar\r\n\r\n">>)).


### PR DESCRIPTION
This PR fixes https://github.com/benoitc/hackney/issues/603 by updating the hparser state without the leading newline.