### PR TITLE
Consume leading newlines in http message

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -168,7 +168,7 @@ parse_first_line(Buffer, St=#hparser{type=Type,
       {error, bad_request};
     1 ->
       << _:16, Rest/binary >> = Buffer,
-      parse_first_line(Rest, St, Empty + 1);
+      parse_first_line(Rest, St#hparser{buffer=Rest}, Empty + 1);
     _ when Type =:= auto ->
       case parse_request_line(St) of
         {request, _Method, _URI, _Version, _NState} = Req -> Req;

--- a/test/hackney_http_tests.erl
+++ b/test/hackney_http_tests.erl
@@ -32,3 +32,16 @@ parse_response_header_with_continuation_line_test() ->
   {header, Header1, ST4} = hackney_http:execute(ST3),
   ?assertEqual({<<"Other-Header">>, <<"test">>}, Header1),
 	{headers_complete, _ST5} = hackney_http:execute(ST4).
+
+parse_request_correct_leading_newlines_test() ->
+	Request = <<"\r\nGET / HTTP/1.1\r\n\r\n">>,
+	ST1 = #hparser{},
+	{request, Verb, Resource, Version, _ST2} = hackney_http:execute(ST1, Request),
+	?assertEqual(Verb, <<"GET">>),
+	?assertEqual(Resource, <<"/">>),
+	?assertEqual(Version, {1,1}).
+
+parse_request_error_too_many_newlines_test() ->
+	Request = <<"\r\nGET / HTTP/1.1\r\n\r\n">>,
+	St = #hparser{max_empty_lines = 0},
+	{error, bad_request} = hackney_http:execute(St, Request).


### PR DESCRIPTION
Split from https://github.com/benoitc/hackney/pull/604:
In this PR the hparser is updated to consume the actual parsed CRLF newlines at the start of the http message.