### PR TITLE
Handle Connection: close response header for streams

### DIFF
--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -328,6 +328,8 @@ read_body(_MaxLength, Client, Acc) ->
 
 maybe_close(#client{socket=nil}) ->
   true;
+maybe_close(#client{connection= <<"close">>}) ->
+  true;
 maybe_close(#client{version={Min,Maj}, headers=Headers, clen=CLen}) ->
   Connection = hackney_bstr:to_lower(
                  hackney_headers_new:get_value(<<"connection">>, Headers, <<"">>)

--- a/test/hackney_stream_tests.erl
+++ b/test/hackney_stream_tests.erl
@@ -2,10 +2,13 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("hackney_lib.hrl").
 
+-export([checkout/4]).
+
 %% This seems necessary to list the tests including the generator
 all_tests() ->
    [
-    async_request()
+    async_request(),
+    heed_connection_close()
    ].
 
 stream_test_() ->
@@ -41,6 +44,26 @@ receive_response(Ref) ->
     StatusCode = orddict:fetch(status, Dict),
     {StatusCode, Keys}.
 
+checkout(_Host, _Port, _Transport, _Client) -> {error, no_socket, make_ref()}.
+heed_connection_close() ->
+    URL = <<"http://localhost:8000/get">>,
+    Options = [async, pool],
+
+    % Notice that ?MODULE has checkout/4 but not checkin, so if this test
+    % passes, it means that checkin was not called (which is intended for closed
+    % sockets)
+    application:set_env(hackney, pool_handler, ?MODULE),
+    {ok, ClientRef} = hackney:get(URL, [], <<>>, Options),
+    application:set_env(hackney, pool_handler, hackney_pool),
+
+    Socket = proplists:get_value(socket, hackney:request_info(ClientRef)),
+    Dict = receive_response(ClientRef, orddict:new()),
+    Headers = hackney_headers_new:from_list(orddict:fetch(headers, Dict)),
+    CloseHeader = hackney_headers_new:get_value(<<"connection">>, Headers),
+    [?_assertEqual(<<"close">>, CloseHeader),
+     ?_assertEqual({error, closed}, gen_tcp:send(Socket, <<>>))
+    ].
+
 receive_response(Ref, Dict0) ->
     receive
         {hackney_response, Ref, {status, Status, _Reason}} ->
@@ -53,4 +76,5 @@ receive_response(Ref, Dict0) ->
         {hackney_response, Ref, Bin} ->
             Dict1 = orddict:append(body, Bin, Dict0),
             receive_response(Ref, Dict1)
+    after 5000 -> {error, timeout}
     end.

--- a/test/hackney_stream_tests.erl
+++ b/test/hackney_stream_tests.erl
@@ -8,7 +8,7 @@
 all_tests() ->
    [
     async_request(),
-    heed_connection_close()
+    handle_connection_close()
    ].
 
 stream_test_() ->
@@ -39,13 +39,13 @@ async_request() ->
      ?_assertEqual([body, headers, status], Keys)].
 
 receive_response(Ref) ->
-    Dict = receive_response(Ref, orddict:new()),
+    Dict = receive_response(Ref, orddict:new(), infinity),
     Keys = orddict:fetch_keys(Dict),
     StatusCode = orddict:fetch(status, Dict),
     {StatusCode, Keys}.
 
 checkout(_Host, _Port, _Transport, _Client) -> {error, no_socket, make_ref()}.
-heed_connection_close() ->
+handle_connection_close() ->
     URL = <<"http://localhost:8000/get">>,
     Options = [async, pool],
 
@@ -57,24 +57,24 @@ heed_connection_close() ->
     application:set_env(hackney, pool_handler, hackney_pool),
 
     Socket = proplists:get_value(socket, hackney:request_info(ClientRef)),
-    Dict = receive_response(ClientRef, orddict:new()),
+    Dict = receive_response(ClientRef, orddict:new(), 5000),
     Headers = hackney_headers_new:from_list(orddict:fetch(headers, Dict)),
     CloseHeader = hackney_headers_new:get_value(<<"connection">>, Headers),
     [?_assertEqual(<<"close">>, CloseHeader),
      ?_assertEqual({error, closed}, gen_tcp:send(Socket, <<>>))
     ].
 
-receive_response(Ref, Dict0) ->
+receive_response(Ref, Dict0, Timeout) ->
     receive
         {hackney_response, Ref, {status, Status, _Reason}} ->
             Dict1 = orddict:store(status, Status, Dict0),
-            receive_response(Ref, Dict1);
+            receive_response(Ref, Dict1, Timeout);
         {hackney_response, Ref, {headers, Headers}} ->
             Dict1 = orddict:store(headers, Headers, Dict0),
-            receive_response(Ref, Dict1);
+            receive_response(Ref, Dict1, Timeout);
         {hackney_response, Ref, done} -> Dict0;
         {hackney_response, Ref, Bin} ->
             Dict1 = orddict:append(body, Bin, Dict0),
-            receive_response(Ref, Dict1)
-    after 5000 -> {error, timeout}
+            receive_response(Ref, Dict1, Timeout)
+    after Timeout -> {error, timeout}
     end.


### PR DESCRIPTION
Due to stream's client not storing the Headers, hackney_response:maybe_close ignores the "Connection: close" response header. This causes that a soon-to-be-closed socket is put back in the pool, potentionally being delivered to other client.

With these changes, hackney_response:maybe_close handles the way hackney_stream stores the connection value