### PR TITLE
Do not normalize when converting relative redirect URL to absolute

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -884,13 +884,12 @@ absolute_url(RelativeUrl, #client{transport=T, host=Host, port=Port,
                   _       -> <<Path/binary, "/", RelativeUrl/binary>>
                 end
             end,
-  Parsed = hackney_url:normalize(#hackney_url{scheme=Scheme,
-                                              host=Host,
-                                              port=Port,
-                                              netloc=Netloc,
-                                              path=NewPath}),
-  hackney_url:unparse_url(Parsed).
 
+  hackney_url:unparse_url(#hackney_url{scheme=Scheme,
+                                       host=Host,
+                                       port=Port,
+                                       netloc=Netloc,
+                                       path=NewPath}).
 
 %% handle send response
 reply({ok, Data, NState}, _State) ->


### PR DESCRIPTION
According to [HTTP/1.1 RFC](https://tools.ietf.org/html/rfc7231#section-7.1.2) the`Location` header value is a single URI-reference. When the reference is relative it should be merged by rules of ["Reference resolution" section of URI RFC](https://tools.ietf.org/html/rfc3986#section-5). From my understanding of that section, no normalization on the relative URI should take place.

### The specific bug I've encountered that this fixes:

Our application generates preview cards for links users submit. We've noticed that the preview links generated for shortened flickr links (i.e `https://flic.kr/p/231oyNG`) are of the wrong picture.

On further investigation I've uncovered that what was happening is:
1. Application uses hackney to request `https://flic.kr/p/231oyNG` with`follow_redirect` set to `true`.
2. Hackney gets the first redirect to`https://www.flickr.com/photo.gne?short=231oyNG`.
3. After requesting that it gets a redirect to `/photo.gne?rb=1&short=231oyNG`
4. Hackney converts that to an absolute url as `https://www.flickr.com/photo.gne%3frb=1%26short=231oyNG`.
5. Hackney requests that url and for some reason that causes flickr to downcase the case-sensitive id of the picture (`231oyng` instead of `231oyNG`), therefore returning the wrong picture.