### PR TITLE
Bump certifi to 2.5.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
 {deps, [
         {idna, "6.0.0"},
         {mimerl, "~>1.1"},
-        {certifi, "2.5.1"},
+        {certifi, "2.5.2"},
         {metrics, "1.0.1"},
         {ssl_verify_fun, "1.1.5"}
        ]}.
@@ -57,4 +57,3 @@
   {base_plt_location, "."},
   {base_plt_prefix, "hackney"}
 ]}.
-

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,5 @@
 {"1.1.0",
-[{<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.1">>},0},
+[{<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.2">>},0},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.0.0">>},0},
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},0},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.2.0">>},0},
@@ -8,7 +8,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},1}]}.
 [
 {pkg_hash,[
- {<<"certifi">>, <<"867CE347F7C7D78563450A18A6A28A8090331E77FA02380B4A21962A65D36EE5">>},
+ {<<"certifi">>, <<"B7CFEAE9D2ED395695DD8201C57A2D019C0C43ECAF8B8BCB9320B40D6662F340">>},
  {<<"idna">>, <<"689C46CBCDF3524C44D5F3DDE8001F364CD7608A99556D8FBD8239A5798D4C10">>},
  {<<"metrics">>, <<"25F094DEA2CDA98213CECC3AEFF09E940299D950904393B2A29D191C346A8486">>},
  {<<"mimerl">>, <<"67E2D3F571088D5CFD3E550C383094B47159F3EEE8FFA08E64106CDF5E981BE3">>},


### PR DESCRIPTION
Any reason `certifi` needs to be pegged to a specific version?