### PR TITLE
Fix further issues with TLS/SSL

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,8 @@
             {platform_define, "R14", no_callback_support},
             {platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "^R", no_proxy_sni_support},
-            {platform_define, "^(19)|(20)", no_customize_hostname_check}
+            {platform_define, "^(19)|(20)", no_customize_hostname_check},
+            {platform_define, "^20", buggy_chacha_ciphers}
            ]}.
 
 {erl_first_files,

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,10 @@
             {platform_define, "^20", no_customize_hostname_check}
            ]}.
 
+{erl_first_files,
+ ["src/hackney_ssl_certificate.erl" % required by `hackney_ssl' at compile time
+ ]}.
+
 {xref_checks, [undefined_function_calls]}.
 
 {cover_enabled, true}.
@@ -20,6 +24,7 @@
         {mimerl, "~>1.1"},
         {certifi, "2.5.2"},
         {metrics, "1.0.1"},
+        {parse_trans, "3.3.0"},
         {ssl_verify_fun, "1.1.6"}
        ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
             {platform_define, "R14", no_callback_support},
             {platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "^R", no_proxy_sni_support},
-            {platform_define, "^20", no_customize_hostname_check}
+            {platform_define, "^(19)|(20)", no_customize_hostname_check}
            ]}.
 
 {erl_first_files,

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"idna">>,{pkg,<<"idna">>,<<"6.0.1">>},0},
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},0},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.2.0">>},0},
- {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.5.0">>},1}]}.
 [

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -15,6 +15,7 @@
       idna,
       mimerl,
       certifi,
+      parse_trans,
       ssl_verify_fun,
       metrics]},
     {included_applications, []},

--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -323,7 +323,10 @@ ssl_opts_1(Host, Options) ->
   Insecure =  proplists:get_value(insecure, Options, false),
   case Insecure of
     true ->
-      [{verify, verify_none}];
+      [{verify, verify_none} | ssl_opts_2()];
     false ->
-      hackney_ssl:check_hostname_opts(Host)
+      hackney_ssl:check_hostname_opts(Host) ++ ssl_opts_2()
   end.
+
+ssl_opts_2() ->
+    hackney_ssl:cipher_opts().

--- a/src/hackney_ssl_certificate.erl
+++ b/src/hackney_ssl_certificate.erl
@@ -1,0 +1,20 @@
+%%% -*- erlang -*-
+%%%
+%%% This file is part of hackney released under the Apache 2 license.
+%%% See the NOTICE for more information.
+%%%
+
+%% @private
+-module(hackney_ssl_certificate).
+
+-include_lib("public_key/include/OTP-PUB-KEY.hrl").
+
+-export(
+   [public_key_info/1
+   ]).
+
+-spec public_key_info(Cert) -> PKI
+        when Cert :: #'OTPCertificate'{tbsCertificate :: TBSCert},
+             TBSCert :: #'OTPTBSCertificate'{subjectPublicKeyInfo :: PKI}.
+public_key_info(Cert) ->
+  ((Cert#'OTPCertificate'.tbsCertificate)#'OTPTBSCertificate'.subjectPublicKeyInfo).


### PR DESCRIPTION
Following your recent changes for OTP 23 support in 66415cf63a, I found some other problems which this PRs proposes fixing.

- broken compilation due to failing `ct_expand` parse transform, fixed in 92c0f4c
- crashing HTTPS requests in OTP 19, fixed in 8eddf7c
- occasional TLS negotiation errors in OTP 20, fixed in 533889d

Cheers,