### PR TITLE
Fix erroneous unexpted message

### DIFF
--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -349,4 +349,16 @@ close(#client{socket=nil}=Client) ->
   Client#client{state = closed};
 close(#client{transport=Transport, socket=Skt}=Client) ->
   Transport:close(Skt),
+  flush(Transport, Skt),
   Client#client{state = closed, socket=nil}.
+
+
+flush(Transport, Socket) ->
+  {Msg, MsgClosed, MsgError} = Transport:messages(Socket),
+  receive
+    {Msg, Socket, _} -> flush(Transport, Socket) ;
+    {MsgClosed, Socket} -> flush(Transport, Socket) ;
+    {MsgError, Socket, _} -> flush(Transport, Socket)
+  after 0 ->
+    ok
+  end.

--- a/src/hackney_stream.erl
+++ b/src/hackney_stream.erl
@@ -120,11 +120,7 @@ maybe_continue(Parent, Owner, Ref, #client{transport=Transport,
       exit({owner_down, Owner, Reason});
     {system, From, Request} ->
       sys:handle_system_msg(Request, From, Parent, ?MODULE, [],
-        {stream_loop, Parent, Owner, Ref, Client});
-    Else ->
-      ?report_trace("stream: unexpected message", [{message, Else}]),
-      error_logger:error_msg("Unexpected message: ~w~n", [Else])
-
+        {stream_loop, Parent, Owner, Ref, Client})
   after 0 ->
     stream_loop(Parent, Owner, Ref, Client)
   end;
@@ -146,10 +142,7 @@ maybe_continue(Parent, Owner, Ref, #client{transport=Transport,
     {system, From, Request} ->
       sys:handle_system_msg(Request, From, Parent, ?MODULE, [],
         {maybe_continue, Parent, Owner, Ref,
-          Client});
-    Else ->
-      ?report_trace("stream: unexpected message", [{message, Else}]),
-      error_logger:error_msg("Unexpected message: ~w~n", [Else])
+          Client})
   after 5000 ->
     Transport:setopts(Socket, [{active, false}]),
     proc_lib:hibernate(?MODULE, maybe_continue, [Parent, Owner, Ref,


### PR DESCRIPTION
* mutually recursive maybe_continue and async_recv
  functions are really tricky to reason about, but
  it doesn't seem like it makes sense for maybe_continue
  to do error handling at all, since async_recv was already
  doing it
  * maybe_continue and stream_loop shouldn't select
    socket messages
  * we're getting into a state where the socket sends
    us a message while we're doing other things and
    we do that receive and then crash
* this change makes async_recv the only one to do
  a select for transport messages

* When the server closes the connection
  and :ssl sends us :ssl_closed, we weren't
  handling the message, which caused it to leak
  into the mailbox even after the request was ended
  * need to flush to make sure it's gone in this case
    where the server hangs up
  * caused when Connection: close header is sent

fix debugging statement