### PR TITLE
Fix spec for qs_vals() type

### DIFF
--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -28,7 +28,7 @@
 
 -include("hackney_lib.hrl").
 
--type qs_vals() :: [{binary(), binary() | true}].
+-type qs_vals() :: [{binary() | atom() | list() | integer(), binary() | true}].
 -type qs_opt() :: noplus | upper.
 
 %% @doc Parse an URL and return a #hackney_url record.


### PR DESCRIPTION
@benoitc the fix applied to hackney_lib. As soon as you merged it there I was like 🤦 wrong repo! 🤪 