### PR TITLE
add new url format for unix socket

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -345,7 +345,7 @@ request(Method, #hackney_url{}=URL0, Headers0, Body, Options0) ->
       Error
   end;
 request(Method, URL, Headers, Body, Options)
-  when is_binary(URL) orelse is_list(URL) ->
+  when is_binary(URL) orelse is_list(URL) orelse is_tuple(URL) ->
   request(Method, hackney_url:parse_url(URL), Headers, Body, Options).
 
 

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -175,9 +175,33 @@ parse_and_unparse_url_test_() ->
                           user = <<"">>,
                           password = <<"">>}
             }
+
             ],
     [{V, fun() -> R = hackney_url:parse_url(V) end} || {V, R} <- Tests] ++
     [{V, fun() -> V = hackney_url:unparse_url(R) end} || {V, R} <- Tests].
+
+
+
+parse_unix_socket_test_() ->
+  Tests = [
+           {{<<"unix:/var/run/test.sock">>, <<"http:user@/path?key=value#Section%205">>},
+             #hackney_url{transport =hackney_local_tcp,
+                          scheme = http_unix,
+                          netloc = <<"%2Fvar%2Frun%2Ftest.sock">>,
+                          raw_path = <<"/path?key=value#Section%205">>,
+                          path = <<"/path">>,
+                          qs = <<"key=value">>,
+                          fragment = <<"Section%205">>,
+                          host = "/var/run/test.sock",
+                          port = 0,
+                          user = <<"user">>,
+                          password = <<"">>}
+           }
+          ],
+
+    [{V, fun() -> R = hackney_url:parse_url(V) end} || {_, {V, R}} <- Tests].
+
+
 
 parse_url_test_() ->
     %% {Value, Result}.


### PR DESCRIPTION
Current way to pass the socket requires the user to url encode the path.
For example `/var/run/mysocket`should be encoded as
`%2Fvar%2Frun%2Fmyscoket` which is not really convenient.

Changes:

We introduce thiss tuple as a ne format `{<<"unix:/var/run/mysock'>>,<<"http://path/to/resource"> }`

This allows the user to pass a path withut encoding it while supporting
extensions in the future.

note: for now only http is suppored.