### PR TITLE
Allow merging of SSL opts

### DIFF
--- a/src/hackney_connection.erl
+++ b/src/hackney_connection.erl
@@ -20,6 +20,7 @@
 
 -export([connect_options/3]).
 -export([ssl_opts/2]).
+-export([merge_ssl_opts/2]).
 
 -include("hackney.hrl").
 
@@ -144,6 +145,18 @@ ssl_opts_1(Host, Options) ->
 ssl_opts_2() ->
   hackney_ssl:cipher_opts().
 
+merge_ssl_opts(Host, OverrideOpts) ->
+  DefaultOpts = ssl_opts_1(Host, OverrideOpts),
+  MergedOpts = orddict:merge(fun(_K, _V1, V) -> V end,
+                             orddict:from_list(DefaultOpts),
+                             orddict:from_list(OverrideOpts)),
+  %% If cacertfile was provided in override opts remove cacerts
+  case lists:keymember(cacertfile, 1, MergedOpts) of
+    true ->
+      lists:keydelete(cacerts, 1, MergedOpts);
+    false ->
+      MergedOpts
+  end.
 
 maybe_tunnel(hackney_http_connect) ->
   true;

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -21,6 +21,7 @@
 
 -export([check_hostname_opts/1]).
 -export([cipher_opts/0]).
+-export([ssl_opts/1]).
 
 %% @doc Atoms used to identify messages in {active, once | true} mode.
 messages(_) -> {ssl, ssl_closed, ssl_error}.
@@ -39,17 +40,20 @@ parse_address(Host) when is_list(Host) ->
 
 check_hostname_opts(Host0) ->
   Host1 = string_compat:strip(Host0, right, $.),
+  check_hostname_opt(Host1, server_name_indication_opt(Host1, ssl_opts(Host1))).
+
+%% @doc Default ssl opts
+ssl_opts(Host0) ->
+  Host1 = string_compat:strip(Host0, right, $.),
   VerifyFun = {
     fun ssl_verify_hostname:verify_fun/3,
     [{check_hostname, Host1}]
-   },
-  SslOpts = [{verify, verify_peer},
-             {depth, 100},
-             {cacerts, certifi:cacerts()},
-             {partial_chain, fun partial_chain/1},
-             {verify_fun, VerifyFun}],
-
-  check_hostname_opt(Host1, server_name_indication_opt(Host1, SslOpts)).
+  },
+  [{verify, verify_peer},
+   {depth, 100},
+   {cacerts, certifi:cacerts()},
+   {partial_chain, fun partial_chain/1},
+   {verify_fun, VerifyFun}].
 
 -ifdef(buggy_chacha_ciphers).
 cipher_opts() ->

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -21,7 +21,6 @@
 
 -export([check_hostname_opts/1]).
 -export([cipher_opts/0]).
--export([ssl_opts/1]).
 
 %% @doc Atoms used to identify messages in {active, once | true} mode.
 messages(_) -> {ssl, ssl_closed, ssl_error}.
@@ -40,20 +39,17 @@ parse_address(Host) when is_list(Host) ->
 
 check_hostname_opts(Host0) ->
   Host1 = string_compat:strip(Host0, right, $.),
-  check_hostname_opt(Host1, server_name_indication_opt(Host1, ssl_opts(Host1))).
-
-%% @doc Default ssl opts
-ssl_opts(Host0) ->
-  Host1 = string_compat:strip(Host0, right, $.),
   VerifyFun = {
     fun ssl_verify_hostname:verify_fun/3,
     [{check_hostname, Host1}]
-  },
-  [{verify, verify_peer},
-   {depth, 100},
-   {cacerts, certifi:cacerts()},
-   {partial_chain, fun partial_chain/1},
-   {verify_fun, VerifyFun}].
+   },
+  SslOpts = [{verify, verify_peer},
+             {depth, 100},
+             {cacerts, certifi:cacerts()},
+             {partial_chain, fun partial_chain/1},
+             {verify_fun, VerifyFun}],
+
+  check_hostname_opt(Host1, server_name_indication_opt(Host1, SslOpts)).
 
 -ifdef(buggy_chacha_ciphers).
 cipher_opts() ->


### PR DESCRIPTION
Related to #654
Since it isn't currently possible to merge your custom ssl opts with the default ones it could be a first step to expose the default ones so that the merging can be done client side.