### PR TITLE
Fixed issue #643 and memory leak in hackney_pool

### DIFF
--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -232,7 +232,7 @@ socket_from_pool(Host, Port, Transport, Client0) ->
     Error ->
       ?report_trace("connect error", []),
       _ = metrics:increment_counter(Metrics, [hackney, Host, connect_error]),
-
+      hackney_manager:cancel_request(Client),
       Error
   end.
 

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -422,7 +422,7 @@ dequeue(Dest, Ref, State) ->
     empty ->
       State#state{clients = Clients2};
     {ok, {From, Ref2, _Requester}, Queues2} ->
-      Pending2 = del_pending(Ref, Pending),
+      Pending2 = del_pending(Ref2, Pending),
       _ = metrics:update_histogram(
             State#state.metrics, [hackney_pool, State#state.name, queue_count], dict:size(Pending2)
            ),


### PR DESCRIPTION
Fixes: https://github.com/benoitc/hackney/issues/643

This is similar to PR https://github.com/benoitc/hackney/pull/656, but using `hackney_manager:cancel_request/1` ensures that request state is also erased from process dictionary and deleted from `hackney_manager_refs` ETS table. 

Additionally, this PR includes a memory leak fix (pending client not removed in `hackney_pool:dequeue`) and some code cleanup. 