### PR TITLE
Prevent xref warning for unmaintained Erlang/OTP function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mime.types
 .rebar
 *.plt
 .rebar
+*_plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - sudo pip install -q gunicorn
 
 script:
+  - ./support/rebar3 xref
   - ./support/rebar3 eunit
   - ./support/rebar3 dialyzer
 

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -262,15 +262,6 @@ start_link(Name, Options0) ->
   gen_server:start_link(?MODULE, [Name, Options], []).
 
 init([Name, Options]) ->
-  case lists:member({seed,1}, ssl:module_info(exports)) of
-    true ->
-      % Make sure that the ssl random number generator is seeded
-      % This was new in R13 (ssl-3.10.1 in R13B vs. ssl-3.10.0 in R12B-5)
-      apply(ssl, seed, [crypto:strong_rand_bytes(255)]);
-    false ->
-      ok
-  end,
-
   MaxConn = case proplists:get_value(pool_size, Options) of
               undefined ->
                 proplists:get_value(max_connections, Options);


### PR DESCRIPTION
I got an `xref` analysis error for an unknown function: `ssl:seed` is not documented in Erlang/OTP's doc.s as "maintained" (it's not there at all), so it's most surely been deprecated a good while ago. I leave it to your judgement to reject the PR (keeping current behavior with no more than a little itch to scratch) or accept it (thus embracing the present and the future).