### PR TITLE
Update netloc in client state when redirecting

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -793,7 +793,8 @@ redirect(Client0, {Method, NewLocation, Headers, Body}) ->
   RedirectUrl = hackney_url:parse_url(NewLocation),
   #hackney_url{transport=RedirectTransport,
                host=RedirectHost,
-               port=RedirectPort}=RedirectUrl,
+               port=RedirectPort,
+               netloc=RedirectNetloc}=RedirectUrl,
 
   #client{transport=Transport,
           host=Host,
@@ -822,6 +823,7 @@ redirect(Client0, {Method, NewLocation, Headers, Body}) ->
   Client2 = Client1#client{transport=RedirectTransport,
                            host=RedirectHost,
                            port=RedirectPort,
+                           netloc=RedirectNetloc,
                            options=Opts},
 
   %% send a request to the new location


### PR DESCRIPTION
This fixes a problem that caused `hackney:location/1` to return the wrong URL after a redirect if the redirect pointed to a different host.