### PR TITLE
Implement GitHub Actions

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,1 +1,35 @@
-
+---
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ci:
+    name: Run checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    container:
+      image: erlang:${{matrix.otp_vsn}}
+    strategy:
+      matrix:
+        otp_vsn: ["19.0", "19.3",
+                  "20.0", "20.1.7", "20.3.8.22",
+                  "21.0.9", "21.1.4", "21.2.7", "21.3.8.1",
+                  "22.0.7", "22.2.8", "22.3.4",
+                  "23.0.2", "23.2"]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          apt-get -q update
+          apt-get -y install python3
+          apt-get -y install python3-pip
+          pip3 install httpbin
+          pip3 install gunicorn
+          gunicorn -b 127.0.0.1:8000 -b unix:httpbin.sock httpbin:app&
+      - run: ./support/rebar3 xref
+      - run: ./support/rebar3 eunit
+      - run: ./support/rebar3 dialyzer

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ __Version:__ 1.16.0
 
 **hackney** is an HTTP client library for Erlang.
 
-[![Build Status](https://travis-ci.org/benoitc/hackney.png?branch=master)](https://travis-ci.org/benoitc/hackney)
+[![Build Status](https://github.com/benoitc/hackney/workflows/build/badge.svg)](https://github.com/benoitc/hackney)
 [![Hex pm](http://img.shields.io/hexpm/v/hackney.svg?style=flat)](https://hex.pm/packages/hackney)
 
 ## Main features:


### PR DESCRIPTION
Main differences to current CI (Travis):
* using stock `rebar3` instead of "latest" (don't know if this is a hard requirement)

Closes #668.