### PR TITLE
breaking change: produce uppercase hexadecimal in urls

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "simple HTTP client"},
-    {vsn, "1.16.0"},
+    {vsn, "1.17.0"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -325,33 +325,33 @@ urlencode(Bin) ->
 
 %% @doc URL encode a string binary.
 %% The `noplus' option disables the default behaviour of quoting space
-%% characters, `\s', as `+'. The `upper' option overrides the default behaviour
-%% of writing hex numbers using lowecase letters to using uppercase letters
+%% characters, `\s', as `+'. The `lower' option overrides the default behaviour
+%% of writing hex numbers using uppercase letters to using lowercase letters
 %% instead.
 -spec urlencode(binary() | string(), [qs_opt()]) -> binary().
 urlencode(Bin, Opts) ->
   Plus = not proplists:get_value(noplus, Opts, false),
-  Upper = proplists:get_value(upper, Opts, false),
-  urlencode(hackney_bstr:to_binary(Bin), <<>>, Plus, Upper).
+  Lower = proplists:get_value(lower, Opts, false),
+  urlencode(hackney_bstr:to_binary(Bin), <<>>, Plus, Lower).
 
 -spec urlencode(binary(), binary(), boolean(), boolean()) -> binary().
-urlencode(<<C, Rest/binary>>, Acc, P=Plus, U=Upper) ->
-  if	C >= $0, C =< $9 -> urlencode(Rest, <<Acc/binary, C>>, P, U);
-    C >= $A, C =< $Z -> urlencode(Rest, <<Acc/binary, C>>, P, U);
-    C >= $a, C =< $z -> urlencode(Rest, <<Acc/binary, C>>, P, U);
+urlencode(<<C, Rest/binary>>, Acc, P=Plus, Lower) ->
+  if	C >= $0, C =< $9 -> urlencode(Rest, <<Acc/binary, C>>, P, Lower);
+    C >= $A, C =< $Z -> urlencode(Rest, <<Acc/binary, C>>, P, Lower);
+    C >= $a, C =< $z -> urlencode(Rest, <<Acc/binary, C>>, P, Lower);
     C =:= $.; C =:= $-; C =:= $~; C =:= $_; C =:= $*; C =:= $@ ->
-      urlencode(Rest, <<Acc/binary, C>>, P, U);
+      urlencode(Rest, <<Acc/binary, C>>, P, Lower);
     C =:= $(; C =:= $); C =:= $!; C =:= $$ ->
-      urlencode(Rest, <<Acc/binary, C>>, P, U);
+      urlencode(Rest, <<Acc/binary, C>>, P, Lower);
     C =:= $ , Plus ->
-      urlencode(Rest, <<Acc/binary, $+>>, P, U);
+      urlencode(Rest, <<Acc/binary, $+>>, P, Lower);
     true ->
       H = C band 16#F0 bsr 4, L = C band 16#0F,
-      H1 = if Upper -> tohexu(H); true -> tohexl(H) end,
-      L1 = if Upper -> tohexu(L); true -> tohexl(L) end,
-      urlencode(Rest, <<Acc/binary, $%, H1, L1>>, P, U)
+      H1 = if Lower -> tohexl(H); true -> tohexu(H) end,
+      L1 = if Lower -> tohexl(L); true -> tohexu(L) end,
+      urlencode(Rest, <<Acc/binary, $%, H1, L1>>, P, Lower)
   end;
-urlencode(<<>>, Acc, _Plus, _Upper) ->
+urlencode(<<>>, Acc, _Plus, _Lower) ->
   Acc.
 
 -spec tohexu(byte()) -> byte().
@@ -479,22 +479,22 @@ partial_pathencode(<<C, Rest/binary>> = Bin, Acc) ->
           M = unhex(L),
           if	G =:= error; M =:= error ->
             H1 = C band 16#F0 bsr 4, L1 = C band 16#0F,
-            H2 = tohexl(H1),
-            L2 = tohexl(L1),
+            H2 = tohexu(H1),
+            L2 = tohexu(L1),
             partial_pathencode(Rest, <<Acc/binary, $%, H2, L2>>);
             true ->
               partial_pathencode(Rest1, <<Acc/binary, $%, H, L>>)
           end;
         _ ->
           H1 = C band 16#F0 bsr 4, L1 = C band 16#0F,
-          H2 = tohexl(H1),
-          L2 = tohexl(L1),
+          H2 = tohexu(H1),
+          L2 = tohexu(L1),
           partial_pathencode(Rest, <<Acc/binary, $%, H2, L2>>)
       end;
     true ->
       H = C band 16#F0 bsr 4, L = C band 16#0F,
-      H1 = tohexl(H),
-      L1 = tohexl(L),
+      H1 = tohexu(H),
+      L1 = tohexu(L),
       partial_pathencode(Rest, <<Acc/binary, $%, H1, L1>>)
   end;
 partial_pathencode(<<>>, Acc) ->

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -301,9 +301,9 @@ transport_scheme_test_() ->
 url_encode_and_decode_test_() ->
     %% {Value, Result}.
     Tests = [
-            {<<"HelloGünter">>, <<"HelloG%c3%bcnter">>},
+            {<<"HelloGünter">>, <<"HelloG%C3%BCnter">>},
             {<<"Hello.-~_">>, <<"Hello.-~_">>},
-            {<<"€£©®ÀÁÂÃÄÅ">>, <<"%e2%82%ac%c2%a3%c2%a9%c2%ae%c3%80%c3%81%c3%82%c3%83%c3%84%c3%85">>}
+            {<<"€£©®ÀÁÂÃÄÅ">>, <<"%E2%82%AC%C2%A3%C2%A9%C2%AE%C3%80%C3%81%C3%82%C3%83%C3%84%C3%85">>}
             ],
     [{V, fun() -> R = hackney_url:urlencode(V) end} || {V, R} <- Tests] ++
     [{R, fun() -> V = hackney_url:urldecode(R) end} || {V, R} <- Tests].
@@ -311,8 +311,8 @@ url_encode_and_decode_test_() ->
 url_encode_test_() ->
     %% {{Url, Options}, Result}.
     Tests = [
-            {{<<"HelloGünter">>, [upper]}, <<"HelloG%C3%BCnter">>},
-            {{<<"Hello+Günter">>, []}, <<"Hello%2bG%c3%bcnter">>},
+            {{<<"HelloGünter">>, [lower]}, <<"HelloG%c3%bcnter">>},
+            {{<<"Hello+Günter">>, []}, <<"Hello%2BG%C3%BCnter">>},
             {{<<"Hello ">>, []}, <<"Hello+">>},
             {{<<"Hello ">>, [noplus]}, <<"Hello%20">>}
             ],


### PR DESCRIPTION
This change the behaviour of urlencode and pathencode to produce
uppercase hexadecimal following the RFC3986:

    The uppercase hexadecimal digits 'A' through 'F' are equivalent to
    the lowercase digits 'a' through 'f', respectively. If two URIs
    differ only in the case of hexadecimal digits used in percent-encoded
    octets, they are equivalent. For consistency, URI producers and
    normalizers should use uppercase hexadecimal digits for all percent-
    encodings.

breaking change that requires to bump the minor release.