### PR TITLE
Explicitly state max_connections and timeout defaults in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ ok = hackney_pool:start_pool(PoolName, Options),
 `timeout` is the time we keep the connection alive in the pool,
 `max_connections` is the number of connections maintained in the pool. Each
 connection in a pool is monitored and closed connections are removed
-automatically.
+automatically. The default timeout is `150000` ms and the default number of connections is `50`.
 
 To close a pool do:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -368,7 +368,7 @@ ok = hackney_pool:start_pool(PoolName, Options),
 `timeout` is the time we keep the connection alive in the pool,
 `max_connections` is the number of connections maintained in the pool. Each
 connection in a pool is monitored and closed connections are removed
-automatically.
+automatically. The default timeout is `150000` ms and the default number of connections is `50`.
 
 To close a pool do:
 


### PR DESCRIPTION
There's no explicitly stated defaults (that I can find) for `max_connections` and `timeout`.

The README examples, if they are examples of the defaults, say `100` for `max_connections` but then [in `hackney.app.src` it seems to be `50`](https://github.com/benoitc/hackney/blob/01bb4249f595e0aa692db28ef23e70f57ae2d4ed/src/hackney.app.src#L25)? I went with that one but if it is something else, please let me know and happy to update my PR.

Either way it would be helpful to have very clearly stated defaults.