### PR TITLE
Fixed slow unix domain socket requests

### DIFF
--- a/src/hackney_connection.erl
+++ b/src/hackney_connection.erl
@@ -98,6 +98,8 @@ new_connection_r(Transport, Host, Port, Id, Tunnel) ->
               tunnel=Tunnel}.
 
 
+connect_options(hackney_local_tcp, _Host, ClientOptions) ->
+  ClientOptions;
 connect_options(Transport, Host, ClientOptions) ->
   ConnectOpts0 = proplists:get_value(connect_options, ClientOptions, []),
 
@@ -162,4 +164,3 @@ maybe_tunnel(hackney_http_connect) ->
   true;
 maybe_tunnel(_) ->
   false.
-

--- a/src/hackney_connection.erl
+++ b/src/hackney_connection.erl
@@ -99,7 +99,8 @@ new_connection_r(Transport, Host, Port, Id, Tunnel) ->
 
 
 connect_options(hackney_local_tcp, _Host, ClientOptions) ->
-  ClientOptions;
+  proplists:get_value(connect_options, ClientOptions, []);
+
 connect_options(Transport, Host, ClientOptions) ->
   ConnectOpts0 = proplists:get_value(connect_options, ClientOptions, []),
 


### PR DESCRIPTION
Hi,

I have been using HTTPoison and by extension hackney in a project and found that when making requests to a Unix domain socket sometimes it would be excruciatingly slow. I finally had some time to track it down and discovered that hackney was doing a DNS lookup on the domain socket path which of course would always fail, but sometimes take a long time to do so.
This little patch fixes this problem.

Thankyou so much for making hackney :)

Daniel