### PR TITLE
Bump parse_trans to version `3.4.1`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
         {mimerl, "~>1.1"},
         {certifi, "~>2.9.0"},
         {metrics, "~>1.0.0"},
-        {parse_trans, "3.3.1"},
+        {parse_trans, "3.4.1"},
         {ssl_verify_fun, "~>1.1.0"},
         {unicode_util_compat, "~>0.7.0"}
        ]}.


### PR DESCRIPTION
Trying to bump `parse_trans` to the latest version.
I am not very familiar with erlang/rebar, please bear with me.