### PR TITLE
Use correct SPDX ID for licenses field

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -28,7 +28,7 @@
       {maxr, 10},
       {maxt, 1}]},
 
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, [{"Github", "https://github.com/benoitc/hackney"}]},
     {files, [
       "src",


### PR DESCRIPTION
The "Apache License 2.0" has the SPDX ID "Apache-2.0", according to the list at https://spdx.org/licenses/. While the string "Apache 2.0" is fully readable for humans, some tools use these fields to verify what licenses are used, and the tools tend to not be as flexible when reading strings that are interpreted as identifiers.