### PR TITLE
Fix partial_pathencode to properly handle asterisk `*`

### DIFF
--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -461,7 +461,7 @@ partial_pathencode(<<C, Rest/binary>> = Bin, Acc) ->
   if	C >= $0, C =< $9 -> partial_pathencode(Rest, <<Acc/binary, C>>);
     C >= $A, C =< $Z -> partial_pathencode(Rest, <<Acc/binary, C>>);
     C >= $a, C =< $z -> partial_pathencode(Rest, <<Acc/binary, C>>);
-    C =:= $;; C =:= $=; C =:= $,; C =:= $:; C =:= $@; C =:= $(; C =:= $) ->
+    C =:= $;; C =:= $=; C =:= $,; C =:= $:; C =:= $*; C =:= $@; C =:= $(; C =:= $) ->
       partial_pathencode(Rest, <<Acc/binary, C>>);
     C =:= $.; C =:= $-; C =:= $+; C =:= $~; C =:= $_ ->
       partial_pathencode(Rest, <<Acc/binary, C>>);

--- a/test/hackney_url_tests.erl
+++ b/test/hackney_url_tests.erl
@@ -382,7 +382,8 @@ pathencode_test_() ->
             {<<"/id/name:107/name2;p=1,3">>, <<"/id/name:107/name2;p=1,3">>},
             {<<"/@foobar">>, <<"/@foobar">>},
             {<<"/500x720/filters:quality(75):format(jpg)/spree/product/s/p/spree2018september12picslgzh0650.jpg">>,
-             <<"/500x720/filters:quality(75):format(jpg)/spree/product/s/p/spree2018september12picslgzh0650.jpg">>}
+             <<"/500x720/filters:quality(75):format(jpg)/spree/product/s/p/spree2018september12picslgzh0650.jpg">>},
+            {<<"/1/indexes/*/queries">>, <<"/1/indexes/*/queries">>}
             ],
     [{V, fun() -> R = hackney_url:pathencode(V) end} || {V, R} <- Tests].
 


### PR DESCRIPTION
Adds case and test for encoding an asterisk in the path adhering to: https://src.chromium.org/viewvc/chrome/trunk/src/url/url_canon_path.cc#l56

### References
- https://github.com/edgurgel/httpoison/issues/471
- https://github.com/benoitc/hackney/issues/399
- https://github.com/benoitc/hackney/issues/277
- https://github.com/benoitc/hackney/issues/272