### PR TITLE
recv: if expected size < BufSize fallback to old behaviour

### DIFF
--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -350,8 +350,10 @@ recv(#client{transport=Transport, socket=Skt, recv_timeout=Timeout}) ->
 
 recv(#client{transport=Transport, socket=Skt, recv_timeout=Timeout}, {_BufSize, undefined}) ->
   Transport:recv(Skt, 0, Timeout);
-recv(#client{transport=Transport, socket=Skt, recv_timeout=Timeout}, {BufSize, ExpectedSize}) ->
-  Transport:recv(Skt, ExpectedSize - BufSize, Timeout).
+recv(#client{transport=Transport, socket=Skt, recv_timeout=Timeout}, {BufSize, ExpectedSize}) when ExpectedSize >= BufSize ->
+  Transport:recv(Skt, ExpectedSize - BufSize, Timeout);
+recv(#client{transport=Transport, socket=Skt, recv_timeout=Timeout}, {_BufSize, _ExpectedSize}) ->
+  Transport:recv(Skt, 0, Timeout).
 
 close(#client{socket=nil}=Client) ->
   Client#client{state = closed};


### PR DESCRIPTION
Ensure we don't pass a negative value to recv?

fix #722