### PR TITLE
HTTP and HTTPS proxies might differ

### DIFF
--- a/include/hackney.hrl
+++ b/include/hackney.hrl
@@ -57,5 +57,5 @@
 
 -define(CONNECTIONS, hackney_connections).
 
--define(HTTP_PROXY_ENV_VARS, ["http_proxy", "HTTP_PROXY"]).
--define(HTTPS_PROXY_ENV_VARS, ["https_proxy", "HTTPS_PROXY"]).
+-define(HTTP_PROXY_ENV_VARS, ["http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"]).
+-define(HTTPS_PROXY_ENV_VARS, ["https_proxy", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"]).

--- a/include/hackney.hrl
+++ b/include/hackney.hrl
@@ -57,4 +57,5 @@
 
 -define(CONNECTIONS, hackney_connections).
 
--define(PROXY_ENV_VARS, ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]).
+-define(HTTP_PROXY_ENV_VARS, ["http_proxy", "HTTP_PROXY"]).
+-define(HTTPS_PROXY_ENV_VARS, ["https_proxy", "HTTPS_PROXY"]).


### PR DESCRIPTION
Hackney handle `HTTP_PROXY` and `HTTPS_PROXY` variables as they define the same thing. In fact (e.g. `curl` documentation) `HTTP_PROXY` should be used only for http requests and `HTTPS_PROXY` should be used only for https requests. This PR fixes that.
Moreover, this PR adds `ALL_PROXY` environment variable handling.