### PR TITLE
fix: ignore empty proxy_env

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -713,6 +713,7 @@ get_proxy_env(S) when S =:= http; S =:= http_unix ->
 get_proxy_env([Var | Rest]) ->
   case os:getenv(Var) of
     false -> get_proxy_env(Rest);
+    "" -> get_proxy_env(Rest);
     Url -> {ok, Url}
   end;
 get_proxy_env([]) ->


### PR DESCRIPTION
When `all_proxy=` it will throw an error:

```
[error] GenServer #PID<0.2401.0> terminating
** (CaseClauseError) no case clause matching: []
    (hackney 1.20.1) deps/hackney/src/hackney_url.erl:248: :hackney_url.parse_netloc/2
    (hackney 1.20.1) deps/hackney/src/hackney.erl:691: :hackney.proxy_from_url/5
    (hackney 1.20.1) deps/hackney/src/hackney.erl:335: :hackney.request/5
    (tesla 1.8.0) lib/tesla/adapter/hackney.ex:75: Tesla.Adapter.Hackney.request/5
    (tesla 1.8.0) lib/tesla/adapter/hackney.ex:37: Tesla.Adapter.Hackney.call/2
```