### PR TITLE
Fix intermittent chunked response hang

### DIFF
--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -285,7 +285,7 @@ body(Client) ->
 body(MaxLength, Client) ->
   read_body(MaxLength, Client, <<>>).
 
--spec skip_body(#client{}) -> {ok, #client{}} | {skip, #client{}} | {error, atom()}.
+-spec skip_body(#client{}) -> {skip, #client{}} | {error, atom()}.
 skip_body(Client) ->
   case stream_body(Client) of
     {ok, _, Client2} -> skip_body(Client2);


### PR DESCRIPTION
When streaming a chunked response, it is possible to cause a TCP receive hang under particular circumstances. If at one point the parser buffer doesn't have the whole chunk, at a later point the buffer ends up empty `<<>>`, and subsequently `hackney_response:stream_body/1` is called, `hackney_response:recv/2` will hang if the expected remaining size exceeds the remainder of the response. That expected size is actually stale, from the earlier point when the parser did not have the whole chunk. This issue slipped in with benoitc/hackney#710.

This was identified when using https://github.com/benoitc/couchbeam and sending several chunked requests. If the last non-terminating chunk completed the response JSON object, `hackney_response:skip_body/1` is called to discard the remaining body, but is told to receive a number of bytes equal to the expected remaining size which will frequently exceed the small terminating chunk and trailers. As a result, the recv operation hangs waiting for bytes that will never arrive.

Now, the transfer state (`BufSize`/`ExpectedSize`) are reset after each successful chunk. The speed benefit of benoitc/hackney#710 is retained (tested with the same approach as in that PR).

- correct some related typespecs