### PR TITLE
fix: infinity opts

### DIFF
--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -126,7 +126,7 @@ connect(Host, Port, Opts) ->
   connect(Host, Port, Opts, 30000).
 
 connect(Host, Port, Opts0, Timeout) when is_list(Host), is_integer(Port),
-                                        (Timeout =:= 5000 orelse is_integer(Timeout)) ->
+                                        (Timeout =:= infinity orelse is_integer(Timeout)) ->
   SSLOpts = proplists:get_value(ssl_options, Opts0),
   BaseOpts = [binary, {active, false}, {packet, raw}],
   Opts1 = hackney_util:merge_opts(BaseOpts, proplists:delete(ssl_options, Opts0)),


### PR DESCRIPTION
fix the :checkout_failure error found after 1.22. https://github.com/benoitc/hackney/commit/c232dee171cc584f716f398721a6116ea5b7bd66