### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp: ["25.3", "26.2", "27.2"]
-        rebar3: ['3.22.1']
+        otp: ["27.3", "28.0"]
+        rebar3: ['3.25.0']
         os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +37,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp: ["22.3", "23.3", "24.3"]
-        rebar3: ['3.18.0']
+        otp: ["24.3", "25.3", "26.2"]
+        rebar3: ['3.22.1']
         os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         otp: ["22.3", "23.3", "24.3"]
         rebar3: ['3.18.0']
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-2012-2025 (c) Benoît Chesneau <bchesneau@pm.me>
+2012-2025 (c) Benoît Chesneau <benoitc@enki-multimedia.eu>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # NEWS
 
+1.24.0 - 2025-05-26
+-------------------
+
+- security: fix basic auth credential exposure vulnerability
+- security: add application variable support for insecure_basic_auth
+- fix: SSL hostname verification with custom ssl_options and SSL message leak in async streaming
+- fix: pool connections not freed on 307 redirects and multiple pool/timer race conditions
+- fix: socket leaks, process deadlocks, ETS memory leaks, and infinite gen_server calls
+- fix: controlling_process error handling in happy eyeballs and connection pool return
+- improvement: update GitHub Actions to ubuntu-22.04 and bump certifi/mimerl dependencies
+
+** Breaking Change **
+
+The new `insecure_basic_auth` application variable defaults to `false` for security.
+If your application relies on insecure basic auth over HTTP, you must explicitly set 
+`application:set_env(hackney, insecure_basic_auth, true)` to maintain previous behavior.
+
 1.23.0 - 2025-02-25
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2012-2025 Benoît Chesneau.
 
-__Version:__ 1.23.0
+__Version:__ 1.25.0
 
 # hackney
 
@@ -29,8 +29,7 @@ __Version:__ 1.23.0
 - Optional socket pool
 - REST syntax: `hackney:Method(URL)` (where a method can be get, post, put, delete, ...)
 
-**Supported versions** of Erlang are 22.3 and above. It is
-reported to work with version from 19.3 to 21.3.
+**Supported versions** of Erlang are 25.3 and above. 
 
 > Note: This is a work in progress, see the
 [TODO](http://github.com/benoitc/hackney/blob/master/TODO.md) for more

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "simple HTTP client"},
-    {vsn, "1.23.0"},
+    {vsn, "1.24.0"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -237,7 +237,10 @@ request(Method, URL, Headers, Body) ->
 %%          redirection for a request</li>
 %%          <li>`{force_redirect, boolean}': false by default, to force the
 %%          redirection even on POST</li>
-%%          <li>`{basic_auth, {binary, binary}}`: HTTP basic auth username and password.</li>
+%%          <li>`{basic_auth, {binary, binary}}`: HTTP basic auth username and password. 
+%%          Only allowed over HTTPS unless {insecure_basic_auth, true} is also set.</li>
+%%          <li>`{insecure_basic_auth, boolean}': false by default. When true, allows 
+%%          basic auth over unencrypted HTTP connections (security risk).</li>
 %%          <li>`{proxy, proxy_options()}': to connect via a proxy.</li>
 %%          <li>`insecure': to perform "insecure" SSL connections and
 %%          transfers without checking the certificate</li>

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -240,7 +240,8 @@ request(Method, URL, Headers, Body) ->
 %%          <li>`{basic_auth, {binary, binary}}`: HTTP basic auth username and password. 
 %%          Only allowed over HTTPS unless {insecure_basic_auth, true} is also set.</li>
 %%          <li>`{insecure_basic_auth, boolean}': false by default. When true, allows 
-%%          basic auth over unencrypted HTTP connections (security risk).</li>
+%%          basic auth over unencrypted HTTP connections (security risk). 
+%%          Can also be set globally via application:set_env(hackney, insecure_basic_auth, true).</li>
 %%          <li>`{proxy, proxy_options()}': to connect via a proxy.</li>
 %%          <li>`insecure': to perform "insecure" SSL connections and
 %%          transfers without checking the certificate</li>

--- a/src/hackney_connection.erl
+++ b/src/hackney_connection.erl
@@ -119,7 +119,7 @@ ssl_opts(Host, Options) ->
     [] ->
       ssl_opts_1(Host, Options);
     SSLOpts ->
-      SSLOpts
+      merge_ssl_opts(Host, SSLOpts)
   end.
 
 ssl_opts_1(Host, Options) ->

--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -111,7 +111,7 @@ close_request(#client{}=Client) ->
 
   %% remove the request
   erase(Ref),
-  ets:delete(?MODULE, Ref),
+  catch ets:delete(?MODULE, Ref),
 
   %% stop to monitor the request
   ok = gen_server:cast(?MODULE, {cancel_request, Ref}),
@@ -224,7 +224,7 @@ get_state(Ref) ->
           %% owner can handle it.
           put(Ref, State),
           %% delete the state, from ets
-          ets:delete(?MODULE, Ref),
+          catch ets:delete(?MODULE, Ref),
           State
       end;
     State ->
@@ -252,7 +252,7 @@ store_state(Ref, NState) ->
 
 take_control(Ref, NState) ->
   %% maybe delete the state from ets
-  ets:delete(?MODULE, Ref),
+  catch ets:delete(?MODULE, Ref),
   %% add the state to the current context
   put(Ref, NState),
   gen_server:call(?MODULE, {take_control, Ref, NState}, infinity).
@@ -413,7 +413,7 @@ handle_cast({cancel_request, Ref}, State) ->
     [{Ref, {Owner, nil, #request_info{pool=Pool}=Info}}] ->
       %% no stream just cancel the request and untrack the owner.
       Pids2 = untrack_owner(Owner, Ref, State#mstate.pids),
-      ets:delete(?REFS, Ref),
+      catch ets:delete(?REFS, Ref),
       %% notify the pool that the request have been canceled
       PoolHandler:notify(Pool, {'DOWN', Ref, request, Owner, cancel}),
       %% update metrics
@@ -423,7 +423,7 @@ handle_cast({cancel_request, Ref}, State) ->
       %% unlink the stream and untrack the owner
       unlink(Stream),
       Pids2 = dict:erase(Stream, untrack_owner(Owner, Ref, State#mstate.pids)),
-      ets:delete(?REFS, Ref),
+      catch ets:delete(?REFS, Ref),
       %% notify the pool that the request have been canceled
       _ = PoolHandler:notify(Pool, {'DOWN', Ref, request, Owner, cancel}),
       %% update metrics
@@ -540,8 +540,8 @@ clean_requests([Ref | Rest], Pid, Reason, PoolHandler, State) ->
       %% cleanup socket
       ok = cleanup_socket(Ref),
       %% remove the reference
-      ets:delete(?REFS, Ref),
-      ets:delete(?MODULE, Ref),
+      catch ets:delete(?REFS, Ref),
+      catch ets:delete(?MODULE, Ref),
       %% notify the pool that the request have been canceled
       PoolHandler:notify(Pool, {'DOWN', Ref, request, Pid, Reason}),
       %% update metrics
@@ -556,8 +556,8 @@ clean_requests([Ref | Rest], Pid, Reason, PoolHandler, State) ->
       %% cleanup socket
       ok = cleanup_socket(Ref),
       %% remove the reference
-      ets:delete(?REFS, Ref),
-      ets:delete(?MODULE, Ref),
+      catch ets:delete(?REFS, Ref),
+      catch ets:delete(?MODULE, Ref),
       %% notify the pool that the request have been canceled
       PoolHandler:notify(Pool, {'DOWN', Ref, request, Pid, Reason}),
       %% update metrics

--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -190,7 +190,7 @@ start_async_response(Ref) ->
   end.
 
 stop_async_response(Ref) ->
-  gen_server:call(?MODULE, {stop_async_response, Ref, self()}, infinity).
+  gen_server:call(?MODULE, {stop_async_response, Ref, self()}, 30000).
 
 async_response_pid(Ref) ->
   case ets:lookup(?REFS, Ref) of
@@ -255,7 +255,7 @@ take_control(Ref, NState) ->
   catch ets:delete(?MODULE, Ref),
   %% add the state to the current context
   put(Ref, NState),
-  gen_server:call(?MODULE, {take_control, Ref, NState}, infinity).
+  gen_server:call(?MODULE, {take_control, Ref, NState}, 30000).
 
 handle_error(#client{request_ref=Ref, dynamic=true}) ->
   close_request(Ref);

--- a/src/hackney_manager.erl
+++ b/src/hackney_manager.erl
@@ -577,14 +577,18 @@ terminate_async_response(StreamPid, Reason) ->
   exit(StreamPid, Reason),
   receive
     {'DOWN', MonitorRef, process, StreamPid, _} ->
+      erlang:demonitor(MonitorRef, [flush]),
       ok
   after 5000 ->
       %% Force kill if not terminated
       exit(StreamPid, kill),
       receive
         {'DOWN', MonitorRef, process, StreamPid, _} ->
+          erlang:demonitor(MonitorRef, [flush]),
           ok
       after 1000 ->
+          %% Process should be dead now, clean up monitor
+          erlang:demonitor(MonitorRef, [flush]),
           ok  %% Give up if still not dead
       end
   end.

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -476,13 +476,9 @@ cancel_timer(Socket, Timer) ->
           ok
       end;
     _ -> 
-      %% Timer was successfully cancelled, but there might still be a message in transit
-      %% Drain it with a short timeout to avoid memory leaks
-      receive
-        {timeout, Socket} -> ok
-      after
-        100 -> ok
-      end
+      %% Timer was successfully cancelled, no message should exist
+      %% Don't drain messages to avoid consuming legitimate timeout messages
+      ok
   end.
 
 %------------------------------------------------------------------------------

--- a/src/hackney_request.erl
+++ b/src/hackney_request.erl
@@ -43,7 +43,7 @@ perform(Client0, {Method0, Path0, Headers0, Body0}) ->
                       maybe_add_cookies(Cookies, [{<<"User-Agent">>, default_ua()}]);
                      {User, Pwd} ->
                        %% Security: Check if basic auth over HTTP is allowed
-                       AllowInsecureAuth = proplists:get_value(insecure_basic_auth, Options, false),
+                       AllowInsecureAuth = proplists:get_value(insecure_basic_auth, Options, hackney_app:get_app_env(insecure_basic_auth, false)),
                        case {Client0#client.transport, AllowInsecureAuth} of
                          {hackney_ssl, _} ->
                            %% HTTPS connection - always safe
@@ -69,7 +69,8 @@ perform(Client0, {Method0, Path0, Headers0, Body0}) ->
                            %% HTTP connection without bypass - reject
                            erlang:error({insecure_basic_auth, 
                                         "Basic authentication over HTTP is insecure. "
-                                        "Use HTTPS or add {insecure_basic_auth, true} option to bypass this check."})
+                                        "Use HTTPS, add {insecure_basic_auth, true} option, or set "
+                                        "application:set_env(hackney, insecure_basic_auth, true) to bypass this check."})
                        end
                    end,
 

--- a/src/hackney_response.erl
+++ b/src/hackney_response.erl
@@ -196,7 +196,7 @@ stream_body_recv_error(Reason, Buffer, Client=#client{version=Version, clen=CLen
     closed ->
       {error, {closed, Buffer}};
     _Else ->
-      {error, Reason}
+      {error, {Reason, Buffer}}
   end.
 
 

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -126,7 +126,7 @@ connect(Host, Port, Opts) ->
   connect(Host, Port, Opts, 30000).
 
 connect(Host, Port, Opts0, Timeout) when is_list(Host), is_integer(Port),
-                                        (Timeout =:= 5000 orelse is_integer(Timeout)) ->
+                                        (Timeout =:= infinity orelse is_integer(Timeout)) ->
   SSLOpts = proplists:get_value(ssl_options, Opts0),
   BaseOpts = [binary, {active, false}, {packet, raw}],
   Opts1 = hackney_util:merge_opts(BaseOpts, proplists:delete(ssl_options, Opts0)),

--- a/src/hackney_stream.erl
+++ b/src/hackney_stream.erl
@@ -106,12 +106,12 @@ maybe_continue(Parent, Owner, Ref, #client{transport=Transport,
     {Ref, resume} ->
       stream_loop(Parent, Owner, Ref, Client);
     {Ref, pause} ->
-      Transport:setopts(Socket, [{active, false}]),
+      _ = Transport:setopts(Socket, [{active, false}]),
       proc_lib:hibernate(?MODULE, maybe_continue, [Parent, Owner, Ref,
         Client]);
     {Ref, stop_async, From} ->
       hackney_manager:store_state(Client#client{async=false}),
-      Transport:setopts(Socket, [{active, false}]),
+      _ = Transport:setopts(Socket, [{active, false}]),
       Transport:controlling_process(Socket, From),
       From ! {Ref, ok};
     {Ref, close} ->
@@ -136,7 +136,7 @@ maybe_continue(Parent, Owner, Ref, #client{transport=Transport,
       stream_loop(Parent, Owner, Ref, Client);
     {Ref, stop_async, From} ->
       hackney_manager:store_state(Client),
-      Transport:setopts(Socket, [{active, false}]),
+      _ = Transport:setopts(Socket, [{active, false}]),
       Transport:controlling_process(Socket, From),
       From ! {Ref, ok};
     {Ref, close} ->
@@ -151,7 +151,7 @@ maybe_continue(Parent, Owner, Ref, #client{transport=Transport,
       ?report_trace("stream: unexpected message", [{message, Else}]),
       error_logger:error_msg("Unexpected message: ~w~n", [Else])
   after 5000 ->
-    Transport:setopts(Socket, [{active, false}]),
+    _ = Transport:setopts(Socket, [{active, false}]),
     proc_lib:hibernate(?MODULE, maybe_continue, [Parent, Owner, Ref,
       Client])
 
@@ -185,7 +185,7 @@ maybe_redirect(Parent, Owner, Ref, StatusInt, Reason, Client) ->
 %% the request is valid.
 maybe_redirect_1(Parent, Owner, Ref, Reason,
                #client{transport=Transport, socket=Socket}=Client) ->
-  Transport:setopts(Socket, [{active, false}]),
+  _ = Transport:setopts(Socket, [{active, false}]),
   case parse(Client) of
     {loop, Client2} ->
       maybe_redirect_1(Parent, Owner, Ref, Reason, Client2);
@@ -221,7 +221,7 @@ maybe_redirect_1(Parent, Owner, Ref, Reason,
 maybe_redirect_2(Parent, Owner, Ref, Reason,
                #client{transport=Transport,
                        socket=Socket}=Client) ->
-      Transport:setopts(Socket, [{active, false}]),
+      _ = Transport:setopts(Socket, [{active, false}]),
       case parse(Client) of
         {loop, Client2} ->
           maybe_redirect_2(Parent, Owner, Ref, Reason, Client2);
@@ -275,14 +275,14 @@ async_recv(Parent, Owner, Ref,
       async_recv(Parent, Owner, Ref, Client, Buffer);
     {Ref, pause} ->
       %% make sure that the process won't be awoken by a tcp msg
-      Transport:setopts(TSock, [{active, false}]),
+      _ = Transport:setopts(TSock, [{active, false}]),
       proc_lib:hibernate(?MODULE, async_recv, [Parent, Owner, Ref,
         Client, Buffer]);
     {Ref, close} ->
       Transport:close(TSock);
     {Ref, stop_async, From} ->
       hackney_manager:store_state(Client#client{async=false}),
-      Transport:setopts(TSock, [{active, false}]),
+      _ = Transport:setopts(TSock, [{active, false}]),
       Transport:controlling_process(TSock, From),
       From ! {Ref, ok};
     {OK, Sock, Data} ->

--- a/test/hackney_integration_tests.erl
+++ b/test/hackney_integration_tests.erl
@@ -75,18 +75,19 @@ not_modified_response() ->
 
 basic_auth_request() ->
     URL = <<"http://localhost:8000/basic-auth/username/password">>,
-    Options = [{basic_auth, {<<"username">>, <<"password">>}}],
+    Options = [{basic_auth, {<<"username">>, <<"password">>}}, {insecure_basic_auth, true}],
     {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, Options),
     ?assertEqual(200, StatusCode).
 
 basic_auth_url_request() ->
     URL = <<"http://username:pass%26word@localhost:8000/basic-auth/username/pass%26word">>,
-    {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, []),
+    Options = [{insecure_basic_auth, true}],
+    {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, Options),
     ?assertEqual(200, StatusCode).
 
 basic_auth_request_failed() ->
     URL = <<"http://localhost:8000/basic-auth/username/password">>,
-    Options = [{basic_auth, {<<"wrong">>, <<"auth">>}}],
+    Options = [{basic_auth, {<<"wrong">>, <<"auth">>}}, {insecure_basic_auth, true}],
     {ok, StatusCode, _, _} = hackney:request(get, URL, [], <<>>, Options),
     ?assertEqual(401, StatusCode).
 

--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -33,7 +33,7 @@ queue_timeout() ->
     fun() ->
         URL = <<"http://localhost:8123/pool">>,
         Headers = [],
-        Opts = [{pool, pool_test}, {connect_timeout, 100}],
+        Opts = [{pool, pool_test}, {connect_timeout, 100}, {checkout_timeout, 5000}],
         case hackney:request(post, URL, Headers, stream, Opts) of
             {ok, Ref} ->
                 {error, _} = hackney:request(post, URL, Headers, stream, Opts),

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -27,7 +27,8 @@ empty_clen_test_() ->
         foreach,
         fun setup/0, fun teardown/1,
         [
-          fun wildcard_cert/1
+          fun wildcard_cert/1,
+          fun custom_ssl_opts_hostname_verification/1
         ]
       }
     }
@@ -46,6 +47,17 @@ stop(_) ->
 wildcard_cert(_) ->
     URL = <<"https://friendpaste.com">>,
     Resp = case hackney:get(URL) of
+             {ok, _, _, _} -> valid;
+             _ -> error
+           end,
+    ?_assertEqual(Resp, valid).
+
+custom_ssl_opts_hostname_verification(_) ->
+    URL = <<"https://www.googleapis.com">>,
+    %% Test with custom ssl_options that should not override hostname verification
+    CustomSSLOpts = [{versions, ['tlsv1.2', 'tlsv1.3']}, {ciphers, []}],
+    Opts = [{ssl_options, CustomSSLOpts}],
+    Resp = case hackney:get(URL, [], <<>>, Opts) of
              {ok, _, _, _} -> valid;
              _ -> error
            end,


### PR DESCRIPTION
miscellaneous fixes:

- security: fix basic auth credential exposure vulnerability
- security: add application variable support for insecure_basic_auth
- fix: SSL hostname verification with custom ssl_options and SSL message leak in async streaming
- fix: pool connections not freed on 307 redirects and multiple pool/timer race conditions
- fix: socket leaks, process deadlocks, ETS memory leaks, and infinite gen_server calls
- fix: controlling_process error handling in happy eyeballs and connection pool return
- improvement: update GitHub Actions to ubuntu-22.04 and bump certifi/mimerl dependencies

** Breaking Change **

The new `insecure_basic_auth` application variable defaults to `false` for security.
If your application relies on insecure basic auth over HTTP, you must explicitly set
`application:set_env(hackney, insecure_basic_auth, true)` to maintain previous behavior.