### PR TITLE
change insecure_basic_auth default to true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+1.25.0 - 2025-07-24
+-------------------
+
+** IMPORTANT CHANGE **
+
+- change: `insecure_basic_auth` now defaults to `true` instead of `false`
+  
+  This restores backward compatibility with pre-1.24.0 behavior where basic auth 
+  was allowed over HTTP connections. If you need strict HTTPS-only basic auth:
+  - Set globally: `application:set_env(hackney, insecure_basic_auth, false)`
+  - Or per-request: `{insecure_basic_auth, false}` in options
+
 1.24.1 - 2025-05-26
 -------------------
 
@@ -17,12 +29,6 @@
 - fix: socket leaks, process deadlocks, ETS memory leaks, and infinite gen_server calls
 - fix: controlling_process error handling in happy eyeballs and connection pool return
 - improvement: update GitHub Actions to ubuntu-22.04 and bump certifi/mimerl dependencies
-
-** Breaking Change **
-
-The new `insecure_basic_auth` application variable defaults to `false` for security.
-If your application relies on insecure basic auth over HTTP, you must explicitly set 
-`application:set_env(hackney, insecure_basic_auth, true)` to maintain previous behavior.
 
 1.23.0 - 2025-02-25
 -------------------

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "simple HTTP client"},
-    {vsn, "1.24.1"},
+    {vsn, "1.25.0"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -239,9 +239,9 @@ request(Method, URL, Headers, Body) ->
 %%          redirection even on POST</li>
 %%          <li>`{basic_auth, {binary, binary}}`: HTTP basic auth username and password. 
 %%          Only allowed over HTTPS unless {insecure_basic_auth, true} is also set.</li>
-%%          <li>`{insecure_basic_auth, boolean}': false by default. When true, allows 
+%%          <li>`{insecure_basic_auth, boolean}': true by default. When true, allows 
 %%          basic auth over unencrypted HTTP connections (security risk). 
-%%          Can also be set globally via application:set_env(hackney, insecure_basic_auth, true).</li>
+%%          Can also be set globally via application:set_env(hackney, insecure_basic_auth, false).</li>
 %%          <li>`{proxy, proxy_options()}': to connect via a proxy.</li>
 %%          <li>`insecure': to perform "insecure" SSL connections and
 %%          transfers without checking the certificate</li>

--- a/src/hackney_request.erl
+++ b/src/hackney_request.erl
@@ -43,7 +43,7 @@ perform(Client0, {Method0, Path0, Headers0, Body0}) ->
                       maybe_add_cookies(Cookies, [{<<"User-Agent">>, default_ua()}]);
                      {User, Pwd} ->
                        %% Security: Check if basic auth over HTTP is allowed
-                       AllowInsecureAuth = proplists:get_value(insecure_basic_auth, Options, hackney_app:get_app_env(insecure_basic_auth, false)),
+                       AllowInsecureAuth = proplists:get_value(insecure_basic_auth, Options, hackney_app:get_app_env(insecure_basic_auth, true)),
                        case {Client0#client.transport, AllowInsecureAuth} of
                          {hackney_ssl, _} ->
                            %% HTTPS connection - always safe


### PR DESCRIPTION
- Bump version to 1.25.0
- Change default from false to true for backward compatibility
- Update documentation and NEWS.md with prominent notice
- Users wanting strict HTTPS-only auth must now explicitly set false