### PR TITLE
Fix pool connection handling regression under load

### DIFF
--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -477,8 +477,8 @@ cancel_timer(Socket, Timer) ->
       receive
         {timeout, Socket} -> ok
       after
-        100 -> 
-          %% Safety timeout - if message doesn't arrive, continue anyway
+        0 -> 
+          %% No wait - if message doesn't exist, continue immediately
           ok
       end;
     _ -> 


### PR DESCRIPTION
## Summary

This PR fixes the performance regression reported in #775 where `checkout_timeout` errors occur under load.

## Problem

The timeout in `cancel_timer/2` was changed from 0ms to 100ms, causing performance issues when the function is called multiple times on the same timer during error scenarios.

## Solution

Restore the original 0ms timeout to eliminate the delay while maintaining proper timer cleanup.

Fixes #775