### PR TITLE
fix: respect connect timeout in ssl:connect

### DIFF
--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -130,9 +130,22 @@ connect(Host, Port, Opts0, Timeout) when is_list(Host), is_integer(Port),
   SSLOpts = proplists:get_value(ssl_options, Opts0),
   BaseOpts = [binary, {active, false}, {packet, raw}],
   Opts1 = hackney_util:merge_opts(BaseOpts, proplists:delete(ssl_options, Opts0)),
+  Now = erlang:monotonic_time(millisecond),
   case hackney_happy:connect(Host, Port, Opts1, Timeout) of
     {ok, Sock} ->
-      ssl:connect(Sock, SSLOpts);
+      case Timeout of
+        infinity ->
+          ssl:connect(Sock, SSLOpts);
+        _ ->
+          Elapsed = erlang:monotonic_time(millisecond) - Now,
+          case Timeout - Elapsed of
+            TimeoutLeft when TimeoutLeft > 0 ->
+              ssl:connect(Sock, SSLOpts, TimeoutLeft);
+            _ ->
+              gen_tcp:close(Sock),
+              {error, timeout}
+          end
+      end;
     Error ->
       Error
   end.


### PR DESCRIPTION
Properly handle timeout for SSL connections by measuring elapsed time during TCP connection phase and passing remaining timeout to SSL handshake.

Closes #776