### PR TITLE
Fix crash caused by no-proxy environment variable

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -794,7 +794,7 @@ test_host_labels([ A | R1], [A | R2]) -> test_host_labels(R1, R2);
 test_host_labels([], _) -> true;
 test_host_labels(_, _) -> false.
 
-test_host_cidr([Addr, Rest], CIDR) ->
+test_host_cidr([Addr | Rest], CIDR) ->
   case hackney_cidr:contains(CIDR, Addr) of
     true -> true;
     false -> test_host_cidr(Rest, CIDR)


### PR DESCRIPTION
Setting the no-proxy environment variable causes the following crash:

`2025-09-03|18:40:18.515|E|<0.2225.0>|0103|** (FunctionClauseError) no function clause matching in :hackney.test_host_cidr/2
    (hackney 1.23.0) /opt/xxx/deps/hackney/src/hackney.erl:789: :hackney.test_host_cidr([{10, 4, 8, 42}], {{10, 4, 8, 41}, {10, 4, 8, 41}, 32})
    (hackney 1.23.0) /opt/xxx/deps/hackney/src/hackney.erl:769: :hackney.do_match_no_proxy_env/4
    (hackney 1.23.0) /opt/xxx/deps/hackney/src/hackney.erl:686: :hackney.maybe_proxy_from_env/6
    (hackney 1.23.0) /opt/xxx/deps/hackney/src/hackney.erl:337: :hackney.request/5
    (httpoison 1.8.2) lib/httpoison/base.ex:846: HTTPoison.Base.request/6`
