### PR TITLE
On pool redirect, don't return client ref as connection is already cleaned up

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -1131,7 +1131,8 @@ reply_response({ok, Status, Headers, #client{request_ref=Ref}=NState}, _State) -
                 _ ->
                   %% For custom pools, use full cleanup to ensure connection release
                   maybe_update_req(CleanNState),
-                  {ok, Status, Headers, Ref}
+                  %% Dont return client ref as connection is already cleaned up
+                  {ok, Status, Headers}
               end;
             Error ->
               hackney_manager:handle_error(NState),

--- a/test/hackney_integration_tests.erl
+++ b/test/hackney_integration_tests.erl
@@ -232,14 +232,8 @@ test_307_redirect_pool_cleanup() ->
         {ok, {maybe_redirect, 307, _Headers1, Client1}} ->
             {skip, _} = hackney:skip_body(Client1),
             ok;
-        {ok, Status1, _Headers1, ClientOrRef1} when Status1 >= 300, Status1 < 400 ->
-            %% If it's a reference, we can't call skip_body - the connection handling is different
-            if is_reference(ClientOrRef1) ->
-                ok;  %% Connection handling is managed internally for pooled requests
-            true ->
-                {skip, _} = hackney:skip_body(ClientOrRef1),
-                ok
-            end;
+        {ok, Status1, _Headers1} when Status1 >= 300, Status1 < 400 ->
+            ok;
         {ok, Status1, _Headers1, Client1} when Status1 >= 200, Status1 < 400 ->
             {ok, _Body} = hackney:body(Client1),
             ok;
@@ -254,13 +248,8 @@ test_307_redirect_pool_cleanup() ->
         {ok, {maybe_redirect, 307, _Headers2, Client2}} ->
             {skip, _} = hackney:skip_body(Client2),
             ok;
-        {ok, Status2, _Headers2, ClientOrRef2} when Status2 >= 300, Status2 < 400 ->
-            if is_reference(ClientOrRef2) ->
-                ok;  %% Connection handling is managed internally for pooled requests
-            true ->
-                {skip, _} = hackney:skip_body(ClientOrRef2),
-                ok
-            end;
+        {ok, Status2, _Headers2} when Status2 >= 300, Status2 < 400 ->
+            ok;
         {ok, Status2, _Headers2, Client2} when Status2 >= 200, Status2 < 400 ->
             {ok, _Body2} = hackney:body(Client2),
             ok;


### PR DESCRIPTION
#717, released in 1.24.0, releases/skips the body when a custom pool is used and a redirect (30X) response is received.

However, in this case it still returns `{ok, Status, Headers, Client}`, leading the HTTPoison library to think it should still fetch the body, which then fails with a `req_not_found` error.

[Reported this downstream](https://github.com/edgurgel/httpoison/issues/503) but would prefer to have it fixed here.