### PR TITLE
remove sort of dns responses

### DIFF
--- a/src/hackney_happy.erl
+++ b/src/hackney_happy.erl
@@ -127,7 +127,7 @@ getbyname(Hostname, Type) ->
   %% First try DNS resolution using inet_res:getbyname
   case (catch inet_res:getbyname(Hostname, Type)) of
     {'ok', #hostent{h_addr_list=AddrList}} -> 
-      lists:usort(AddrList);
+      AddrList;
     {error, _Reason} -> 
       %% DNS failed, try fallback to /etc/hosts using inet:gethostbyname
       %% This fixes NXDOMAIN errors in Docker Compose environments where
@@ -150,7 +150,7 @@ fallback_hosts_lookup(Hostname, Type) ->
   end,
   case (catch inet:gethostbyname(Hostname, InetType)) of
     {'ok', #hostent{h_addr_list=AddrList}} -> 
-      lists:usort(AddrList);
+      AddrList;
     _ -> 
       []
   end.


### PR DESCRIPTION
This PR stops sorting the resolver’s address list in hackney_happy:getbyname/2 by replacing lists:usort(AddrList) with AddrList. The current sorting removes duplicates and reorders IPs, which unintentionally breaks DNS randomness and can cause uneven connection distribution.

Rationale
DNS randomness is a common, simple load-spreading mechanism. Reordering results undermines it.
Duplicate handling is typically the resolver’s responsibility. If duplicates occur, they are rare and harmless; removing them here is not worth the cost of losing order.