### PR TITLE
Fix no_proxy host labels check.

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -784,7 +784,7 @@ do_match_no_proxy_env([{host, _Labels} | _] = Patterns, Addrs, undefined, Host)
 do_match_no_proxy_env([{host, Labels} | Rest], Addrs, HostLabels, Host) ->
   case test_host_labels(Labels, HostLabels) of
     true -> true;
-    false -> do_match_no_proxy_env(Rest, Addrs, Labels, Host)
+    false -> do_match_no_proxy_env(Rest, Addrs, HostLabels, Host)
   end;
 do_match_no_proxy_env([], _, _, _) ->
   false.


### PR DESCRIPTION
Ensures that the labels passed forward in `no_proxy` checks are the host labels, not the previous `no_proxy` spec.