### PR TITLE
fix: tolerate trailing semicolons in parameter parsing (#618)

### DIFF
--- a/src/hackney_bstr.erl
+++ b/src/hackney_bstr.erl
@@ -220,9 +220,16 @@ params(Data, Fun) ->
 params(Data, Fun, Acc) ->
   whitespace(Data,
     fun (<< $;, Rest/binary >>) ->
-      param(Rest,
-        fun (Rest2, Attr, Value) ->
-          params(Rest2, Fun, [{Attr, Value}|Acc])
+      %% Check for trailing semicolon (no parameter after it)
+      whitespace(Rest,
+        fun (<<>>) ->
+          %% Trailing semicolon with no parameter - just return accumulated params
+          Fun(<<>>, lists:reverse(Acc));
+            (Rest2) ->
+          param(Rest2,
+            fun (Rest3, Attr, Value) ->
+              params(Rest3, Fun, [{Attr, Value}|Acc])
+            end)
         end);
         (Rest) ->
           Fun(Rest, lists:reverse(Acc))

--- a/test/hackney_bstr_tests.erl
+++ b/test/hackney_bstr_tests.erl
@@ -85,7 +85,9 @@ params_test_() ->
             {<<";c=d">>, [<<>>,{<<"c">>,<<"d">>}]},
             {<<";a=b;c=d">>, [<<>>,{<<"a">>,<<"b">>},{<<"c">>,<<"d">>}]},
             {<<";ab">>, {error, badarg}},
-            {<<";a=b;">>, {error, badarg}},
+            %% Issue #618: trailing semicolons should be tolerated
+            {<<";a=b;">>, [<<>>,{<<"a">>,<<"b">>}]},
+            {<<";a=b;c=d;">>, [<<>>,{<<"a">>,<<"b">>},{<<"c">>,<<"d">>}]},
             {<<" ;a=b;c=d">>, [<<>>,{<<"a">>,<<"b">>},{<<"c">>,<<"d">>}]}
             ],
     [{V, fun() -> R = hackney_bstr:params(V, F) end} || {V, R} <- Tests].


### PR DESCRIPTION
## Summary
- Headers like `Content-Disposition: attachment; filename="test.html";` with a trailing semicolon are technically valid and accepted by browsers
- Previously this would fail with `{error, badarg}`
- The fix checks if there's only whitespace after a semicolon and returns the accumulated parameters instead of failing

Fixes #618