### PR TITLE
fix: strip auth credentials on cross-host redirects (#701)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,10 @@ The connection pool has been completely redesigned:
 - `send_multipart_body/2` - use `send_body/2`
 - SOCKS5 and HTTP CONNECT proxy (planned 2.1.0)
 
+### Security
+
+- **BREAKING**: Authorization credentials and cookies are no longer sent on cross-host redirects by default (CVE-2018-1000007). This prevents credential leakage when a server redirects to a different host (e.g., API redirecting to S3). To restore the old behavior, use `{location_trusted, true}` option (similar to curl's `--location-trusted`).
+
 ### Bug Fixes
 
 - fix: validate connection state on pool checkout for HTTP/2 and HTTP/3. On FreeBSD + OTP 28, pooled connections could be in `closed` state when checked out due to SSL timing differences, causing `{error, invalid_state}` errors. Now connections are verified to be in `connected` state after checkout.


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: Authorization credentials (`basic_auth`) and cookies are no longer forwarded when following redirects to a different host
- This prevents credential leakage similar to CVE-2018-1000007 in cURL
- New `location_trusted` option (like curl's `--location-trusted`) allows restoring old behavior when needed

## Example
```erlang
%% Credentials will NOT be sent to s3.amazonaws.com
hackney:get("https://api.example.com/file", [], <<>>, [
    {basic_auth, {"user", "pass"}},
    {follow_redirect, true}
])

%% To explicitly trust all redirect targets:
hackney:get("https://api.example.com/file", [], <<>>, [
    {basic_auth, {"user", "pass"}},
    {follow_redirect, true},
    {location_trusted, true}
])
```

Fixes #701