### PR TITLE
fix: remove parse_trans from runtime dependencies (#714)

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -15,7 +15,6 @@
       idna,
       mimerl,
       certifi,
-      parse_trans,
       ssl_verify_fun,
       metrics,
       unicode_util_compat]},


### PR DESCRIPTION
## Summary

- Removes `parse_trans` from the `applications` list in `hackney.app.src`
- `parse_trans` provides `ct_expand` which is only used at compile time (for computing cipher suites and decoding CA certificates)
- Results are baked into `.beam` files at compile time, so `parse_trans` is not needed at runtime

This reduces the runtime dependency chain: `hackney` → `parse_trans` → `syntax_tools`

Particularly helpful for environments without `syntax_tools` (e.g., elixir-desktop).

Closes #714