### PR TITLE
fix: handle non-standard decimal status codes (#697)

### DIFF
--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -232,7 +232,12 @@ parse_status(<< C, Rest/bits >>, St, Version, Acc) ->
   end.
 
 parse_reason(Reason, St, Version, StatusCode) ->
-  StatusInt = list_to_integer(binary_to_list(StatusCode)),
+  %% Handle non-standard decimal status codes (e.g., 401.1 from IIS) by truncating
+  StatusCodeInt = case binary:split(StatusCode, <<".">>) of
+    [IntPart, _DecPart] -> IntPart;
+    [IntPart] -> IntPart
+  end,
+  StatusInt = list_to_integer(binary_to_list(StatusCodeInt)),
 
   NState = St#hparser{type=response,
     version=Version,


### PR DESCRIPTION
## Summary

- Handles non-standard decimal status codes like `401.1` from IIS servers
- Truncates at the decimal point since HTTP status codes are 3-digit integers per RFC 7231
- Microsoft IIS uses extended status codes like `401.1`, `403.14`, etc.

Closes #697