### PR TITLE
feat: support HTTP 1xx informational responses (#631)

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -862,7 +862,12 @@ sync_request_with_redirect(ConnPid, Method, Path, Headers, Body, WithBody, Optio
 
 sync_request_with_redirect_body(ConnPid, Method, Path, HeadersList, FinalBody,
                                 WithBody, Options, URL, FollowRedirect, MaxRedirect, RedirectCount) ->
-  case hackney_conn:request(ConnPid, Method, Path, HeadersList, FinalBody) of
+  %% Extract request options for 1xx informational responses
+  ReqOpts = case proplists:get_value(inform_fun, Options) of
+    undefined -> [];
+    InformFun -> [{inform_fun, InformFun}]
+  end,
+  case hackney_conn:request(ConnPid, Method, Path, HeadersList, FinalBody, infinity, ReqOpts) of
     %% HTTP/2 returns body directly - handle 4-tuple first
     {ok, Status, RespHeaders, RespBody} when Status >= 301, Status =< 303; Status =:= 307; Status =:= 308 ->
       %% HTTP/2 redirect status

--- a/src/hackney_http.erl
+++ b/src/hackney_http.erl
@@ -184,10 +184,9 @@ parse_first_line(Buffer, St=#hparser{type=Type,
     _ when Type =:= response ->
       case parse_response_line(St) of
 	  {error, bad_request} -> {error, bad_request};
-	  {response, Version, StatusInt, Reason, NState} when StatusInt >= 200 ->
-	      {response, Version, StatusInt, Reason, NState};
-	  {response, _Version, _StatusInt, _Reason, _NState} ->
-	      {more, St#hparser{empty_lines=Empty, state=on_junk}}
+	  %% Return all responses including 1xx informational (issue #631)
+	  {response, Version, StatusInt, Reason, NState} ->
+	      {response, Version, StatusInt, Reason, NState}
       end;
     _ when Type =:= request ->
       parse_request_line(St)


### PR DESCRIPTION
## Summary

- Adds `inform_fun` option for handling HTTP 1xx informational responses per RFC 7231 Section 6.2
- For sync requests: `inform_fun(Status, Reason, HeadersList)` callback is invoked
- For async requests: `{hackney_response, AsyncRef, {informational, Status, Reason, Headers}}` message sent to `stream_to` process
- If no callback is set, 1xx responses are silently skipped (per HTTP spec)
- Parser now correctly returns 1xx responses instead of treating them as junk

This enables use cases like HTTP 103 Early Hints for preloading resources.

Closes #631