### PR TITLE
feat: add peercert/1 function to get peer SSL certificate (#599)

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -11,6 +11,7 @@
 -export([connect/1, connect/2, connect/3, connect/4,
          close/1,
          peername/1,
+         peercert/1,
          sockname/1,
          request/1, request/2, request/3, request/4, request/5,
          send_request/2,
@@ -400,6 +401,13 @@ normalize_transport(Other) -> Other.
 -spec peername(conn()) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.
 peername(ConnPid) when is_pid(ConnPid) ->
   hackney_conn:peername(ConnPid).
+
+%% @doc Get the peer SSL certificate.
+%% Returns the DER-encoded certificate of the peer, or an error if the connection
+%% is not SSL or the certificate is unavailable.
+-spec peercert(conn()) -> {ok, binary()} | {error, term()}.
+peercert(ConnPid) when is_pid(ConnPid) ->
+  hackney_conn:peercert(ConnPid).
 
 %% @doc Get the local address and port.
 -spec sockname(conn()) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -15,6 +15,7 @@
   setopts/2,
   controlling_process/2,
   peername/1,
+  peercert/1,
   close/1,
   shutdown/2,
   sockname/1]).
@@ -236,6 +237,13 @@ controlling_process(Socket, Pid) ->
   {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
 peername(Socket) ->
   ssl:peername(Socket).
+
+%% @doc Return the peer certificate of an SSL connection.
+%% @see ssl:peercert/1
+-spec peercert(ssl:sslsocket()) ->
+  {ok, binary()} | {error, atom()}.
+peercert(Socket) ->
+  ssl:peercert(Socket).
 
 %% @doc Close a TCP socket.
 %% @see ssl:close/1


### PR DESCRIPTION
## Summary
- Add `hackney:peercert/1` function to retrieve the DER-encoded peer SSL certificate
- Returns `{ok, Cert}` for SSL connections, `{error, not_ssl}` for non-SSL, `{error, not_connected}` if disconnected
- Implemented in `hackney_ssl`, `hackney_conn`, and `hackney` modules

Fixes #599