### PR TITLE
fix: no_proxy parsing bugs

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -26,7 +26,9 @@
          cancel_request/1,
          setopts/2]).
 
--export([redirect_location/1]).
+-export([redirect_location/1,
+         parse_no_proxy_env/2,
+         match_no_proxy_env/2]).
 
 -export([stream_next/1,
          stop_async/1,
@@ -751,7 +753,7 @@ parse_no_proxy_env([S | Rest], Acc) ->
   catch
     _:_ ->
       Labels = string:tokens(S, "."),
-      parse_no_proxy_env(Rest, [{host, lists:reverse(Labels)}])
+      parse_no_proxy_env(Rest, [{host, lists:reverse(Labels)} | Acc])
   end;
 parse_no_proxy_env([], Acc) ->
   NoProxy = lists:reverse(Acc),
@@ -777,10 +779,10 @@ do_match_no_proxy_env([{cidr, CIDR} | Rest], Addrs, Labels, Host) ->
 do_match_no_proxy_env([{host, _Labels} | _] = Patterns, Addrs, undefined, Host) ->
   HostLabels = string:tokens(Host, "."),
   do_match_no_proxy_env(Patterns, Addrs, lists:reverse(HostLabels), Host);
-do_match_no_proxy_env([{host, Labels} | Rest], Addrs, HostLabels, Host) ->
+do_match_no_proxy_env([{host, Labels} | Rest], Addrs, HostLabels, Host) ->
   case test_host_labels(Labels, HostLabels) of
     true -> true;
-    false -> do_match_no_proxy_env(Rest, Addrs, Labels, Host)
+    false -> do_match_no_proxy_env(Rest, Addrs, HostLabels, Host)
   end;
 do_match_no_proxy_env([], _, _, _) ->
   false.

--- a/src/hackney_happy.erl
+++ b/src/hackney_happy.erl
@@ -124,22 +124,33 @@ getaddrs(Name) ->
   {IP6Addrs, IP4Addrs}.
 
 getbyname(Hostname, Type) ->
-  %% First try DNS resolution using inet_res:getbyname
-  case (catch inet_res:getbyname(Hostname, Type)) of
+  case hosts_lookup_first(Hostname, Type) of
+    [] ->
+      case (catch inet_res:getbyname(Hostname, Type)) of
+        {'ok', #hostent{h_addr_list=AddrList}} -> 
+          lists:usort(AddrList);
+        {error, _Reason} -> 
+          fallback_hosts_lookup(Hostname, Type);
+        Else ->
+          ?report_debug("DNS error", [{hostname, Hostname}
+                                     ,{type, Type}
+                                     ,{error, Else}]),
+          fallback_hosts_lookup(Hostname, Type)
+      end;
+    Addrs ->
+      Addrs
+  end.
+
+hosts_lookup_first(Hostname, Type) ->
+  InetType = case Type of
+    a -> inet;
+    aaaa -> inet6
+  end,
+  case (catch inet_hosts:gethostbyname(Hostname, InetType)) of
     {'ok', #hostent{h_addr_list=AddrList}} -> 
       lists:usort(AddrList);
-    {error, _Reason} -> 
-      %% DNS failed, try fallback to /etc/hosts using inet:gethostbyname
-      %% This fixes NXDOMAIN errors in Docker Compose environments where
-      %% hostnames are resolved via /etc/hosts entries
-      fallback_hosts_lookup(Hostname, Type);
-    Else ->
-      %% ERLANG 22 has an issue when g matching some DNS server messages
-      ?report_debug("DNS error", [{hostname, Hostname}
-                                 ,{type, Type}
-                                 ,{error, Else}]),
-      %% Try fallback on unexpected errors too
-      fallback_hosts_lookup(Hostname, Type)
+    _ -> 
+      []
   end.
 
 %% Fallback to check /etc/hosts when DNS resolution fails

--- a/src/hackney_happy.erl
+++ b/src/hackney_happy.erl
@@ -124,33 +124,22 @@ getaddrs(Name) ->
   {IP6Addrs, IP4Addrs}.
 
 getbyname(Hostname, Type) ->
-  case hosts_lookup_first(Hostname, Type) of
-    [] ->
-      case (catch inet_res:getbyname(Hostname, Type)) of
-        {'ok', #hostent{h_addr_list=AddrList}} -> 
-          lists:usort(AddrList);
-        {error, _Reason} -> 
-          fallback_hosts_lookup(Hostname, Type);
-        Else ->
-          ?report_debug("DNS error", [{hostname, Hostname}
-                                     ,{type, Type}
-                                     ,{error, Else}]),
-          fallback_hosts_lookup(Hostname, Type)
-      end;
-    Addrs ->
-      Addrs
-  end.
-
-hosts_lookup_first(Hostname, Type) ->
-  InetType = case Type of
-    a -> inet;
-    aaaa -> inet6
-  end,
-  case (catch inet_hosts:gethostbyname(Hostname, InetType)) of
+  %% First try DNS resolution using inet_res:getbyname
+  case (catch inet_res:getbyname(Hostname, Type)) of
     {'ok', #hostent{h_addr_list=AddrList}} -> 
       lists:usort(AddrList);
-    _ -> 
-      []
+    {error, _Reason} -> 
+      %% DNS failed, try fallback to /etc/hosts using inet:gethostbyname
+      %% This fixes NXDOMAIN errors in Docker Compose environments where
+      %% hostnames are resolved via /etc/hosts entries
+      fallback_hosts_lookup(Hostname, Type);
+    Else ->
+      %% ERLANG 22 has an issue when g matching some DNS server messages
+      ?report_debug("DNS error", [{hostname, Hostname}
+                                 ,{type, Type}
+                                 ,{error, Else}]),
+      %% Try fallback on unexpected errors too
+      fallback_hosts_lookup(Hostname, Type)
   end.
 
 %% Fallback to check /etc/hosts when DNS resolution fails

--- a/test/hackney_no_proxy_tests.erl
+++ b/test/hackney_no_proxy_tests.erl
@@ -1,0 +1,81 @@
+-module(hackney_no_proxy_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(clear_cache(), application:unset_env(hackney, no_proxy)).
+
+parse_single_host_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env(["my-internal-host"], []),
+  ?assertEqual([{host, ["my-internal-host"]}], Result).
+
+parse_multiple_hosts_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env(["my-internal-host", "api.example.org"], []),
+  ?assertEqual([
+    {host, ["my-internal-host"]},
+    {host, ["org", "example", "api"]}
+  ], Result).
+
+parse_domain_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env(["example.com"], []),
+  ?assertEqual([{host, ["com", "example"]}], Result).
+
+parse_leading_dot_domain_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env([".example.com"], []),
+  ?assertEqual(["example", "com"], string:tokens(".example.com", ".")),
+  ?assertEqual([{host, ["com", "example"]}], Result).
+
+parse_wildcard_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env(["*"], []),
+  ?assertEqual('*', Result).
+
+parse_cidr_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env(["192.168.0.0/16"], []),
+  ?assertMatch([{cidr, _}], Result).
+
+parse_mixed_test() ->
+  ?clear_cache(),
+  Result = hackney:parse_no_proxy_env(["192.168.0.0/16", "example.com", "localhost"], []),
+  ?assertMatch([{cidr, _}, {host, ["com", "example"]}, {host, ["localhost"]}], Result).
+
+match_exact_host_test() ->
+  ?clear_cache(),
+  Patterns = hackney:parse_no_proxy_env(["my-internal-host"], []),
+  ?assert(hackney:match_no_proxy_env(Patterns, "my-internal-host")),
+  ?assertNot(hackney:match_no_proxy_env(Patterns, "other-host")).
+
+match_domain_suffix_test() ->
+  ?clear_cache(),
+  Patterns = hackney:parse_no_proxy_env([".example.com"], []),
+  ?assert(hackney:match_no_proxy_env(Patterns, "example.com")),
+  ?assert(hackney:match_no_proxy_env(Patterns, "sub.example.com")),
+  ?assertNot(hackney:match_no_proxy_env(Patterns, "other.com")).
+
+match_subdomain_test() ->
+  ?clear_cache(),
+  Patterns = hackney:parse_no_proxy_env(["example.com"], []),
+  ?assert(hackney:match_no_proxy_env(Patterns, "example.com")),
+  ?assert(hackney:match_no_proxy_env(Patterns, "sub.example.com")),
+  ?assert(hackney:match_no_proxy_env(Patterns, "a.b.example.com")),
+  ?assertNot(hackney:match_no_proxy_env(Patterns, "other.com")).
+
+match_multiple_hosts_test() ->
+  ?clear_cache(),
+  Patterns = hackney:parse_no_proxy_env(["my-internal-host", "api.example.org"], []),
+  ?assert(hackney:match_no_proxy_env(Patterns, "my-internal-host")),
+  ?assert(hackney:match_no_proxy_env(Patterns, "api.example.org")),
+  ?assertNot(hackney:match_no_proxy_env(Patterns, "other-host")),
+  ?assertNot(hackney:match_no_proxy_env(Patterns, "other.example.org")).
+
+match_no_proxy_false_test() ->
+  ?assertNot(hackney:match_no_proxy_env(false, "example.com")),
+  ?assertNot(hackney:match_no_proxy_env(false, "any-host")).
+
+match_no_proxy_wildcard_test() ->
+  ?assert(hackney:match_no_proxy_env('*', "anything")),
+  ?assert(hackney:match_no_proxy_env('*', "localhost")),
+  ?assert(hackney:match_no_proxy_env('*', "192.168.1.1")).


### PR DESCRIPTION
Fix: no_proxy environment variable parsing bugs
This PR fixes issues with parsing the no_proxy environment variable, based on version 1.25.0.
Problem:
When NO_PROXY contains multiple comma-separated hosts, only the last entry is honored. All preceding entries are silently ignored. 

Note for maintainer:
This is branched from 1.25.0 as i am unable to upgrade to the latest verstion at this time. 