### PR TITLE
release(4.0.0): version bump + release notes

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -17,7 +17,7 @@ Add hackney to your `rebar.config`:
 Add to your `mix.exs`:
 
 ```elixir
-{:hackney, "~> 3.0"}
+{:hackney, "~> 4.0"}
 ```
 
 ## Starting hackney

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,17 @@
 # NEWS
 
-UNRELEASED
-----------
+4.0.0 - 2026-04-16
+------------------
+
+Hackney 4 trims the client down. The HTTP/2 and HTTP/3 stacks are now
+delegated to `erlang_h2` and `erlang_quic`, so hackney no longer ships
+its own framing, HPACK / QPACK codecs, control streams or state
+machines. The HTTP/3 path is fully spec-compliant via `quic_h3`, with
+ALPN negotiation, Alt-Svc discovery (RFC 7838), and the same
+`hackney:request/5` API as HTTP/1.1. The bundled metrics subsystem is
+gone too, replaced by a Go-style middleware chain that lets users plug
+in prometheus, telemetry or anything else without hackney owning the
+policy. See `guides/middleware.md` and `guides/http3_guide.md`.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Payload = <<"{\"key\": \"value\"}">>,
 ### Mix
 
 ```elixir
-{:hackney, "~> 3.0"}
+{:hackney, "~> 4.0"}
 ```
 
 ## Documentation

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "3.2.1"},
+    {vsn, "4.0.0"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,
@@ -16,7 +16,8 @@
       mimerl,
       certifi,
       ssl_verify_fun,
-      h2]},
+      h2,
+      quic]},
     {included_applications, []},
     {mod, { hackney_app, []}},
     {env, [{timeout, 150000},


### PR DESCRIPTION
Bumps to 4.0.0 and rewrites the UNRELEASED entry with an introductory paragraph covering the h2/quic delegation, HTTP/3 spec compliance, and the new middleware chain. Adds `quic` to the application list so HTTP/3 starts cleanly.