### PR TITLE
fix(exdoc): drop unsupported source_ref, skip warnings on NEWS/MIGRATION

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -91,7 +91,9 @@
     ]},
     {main, "README.md"},
     {source_url, "https://github.com/benoitc/hackney"},
-    {source_ref, <<"master">>}
+    %% Historical release notes reference functions that have since been
+    %% removed; suppress those auto-link warnings.
+    {skip_undefined_reference_warnings_on, ["NEWS.md", "guides/MIGRATION.md"]}
 ]}.
 
 %% == Dialyzer ==


### PR DESCRIPTION
rebar3_ex_doc rejects `source_ref`. NEWS.md and MIGRATION.md reference removed APIs; skip auto-link warnings for both. ex_doc output now clean.