### PR TITLE
deps: bump h2 to 0.6.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -51,7 +51,7 @@
         %% Pure Erlang QUIC + HTTP/3 stack
         {quic, "1.0.0"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "0.4.0"},
+        {h2, "0.6.0"},
         {idna, "~>7.1.0"},
         {mimerl, "~>1.4"},
         {certifi, "~>2.16.0"},

--- a/test/hackney_http2_concurrency_tests.erl
+++ b/test/hackney_http2_concurrency_tests.erl
@@ -30,10 +30,14 @@ run_concurrent_tight_loop() ->
         ok = h2:send_data(Conn, Sid, <<"ok">>, true)
     end,
     Certs = cert_dir(),
+    %% h2 0.6.0 defaults SETTINGS_MAX_CONCURRENT_STREAMS to 100 (RFC 9113
+    %% §5.1.2 floor); this tight-loop test multiplexes more than that and
+    %% would otherwise hit {error, max_streams_exceeded}.
     {ok, Server} = h2:start_server(0, #{
         cert => filename:join(Certs, "server.pem"),
         key  => filename:join(Certs, "server.key"),
-        handler => Handler
+        handler => Handler,
+        settings => #{max_concurrent_streams => unlimited}
     }),
     Port = h2:server_port(Server),
     Pool = hackney_h2_concurrency_pool,


### PR DESCRIPTION
Updates h2 from 0.4.0 to 0.6.0.

h2 0.6.0 sets the default SETTINGS_MAX_CONCURRENT_STREAMS to 100 (RFC 9113 §5.1.2 floor). The HTTP/2 concurrency regression test runs a tight loop that multiplexes beyond that, so the test server is now configured with max_concurrent_streams => unlimited to keep exercising the original connection-wedge regression.

Other 0.6.0 behavior changes (send_data may return {error, send_buffer_full}, send_request_headers/send_data error propagation on closed sockets) are already handled by hackney_conn's existing {error, _} matching, so no client code changes are needed.

All 823 eunit tests pass.