### PR TITLE
Fix dialyzer specs

### DIFF
--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -14,8 +14,7 @@ no registry, no deps.
 
 -type response() :: {ok, integer(), list(), binary()}
                   | {ok, integer(), list()}         %% HEAD
-                  | {ok, reference()}               %% async
-                  | {ok, pid()}                     %% streaming upload
+                  | {ok, pid()}                     %% async or streaming upload
                   | {error, term()}.
 
 -type next()       :: fun((request()) -> response()).

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -76,7 +76,7 @@
 -type request_ret() ::
     {ok, integer(), list(), binary()} | %% response with body
     {ok, integer(), list()} |           %% HEAD request
-    {ok, reference()} |                 %% async mode
+    {ok, conn()} |                      %% async mode or streaming body upload (body = stream)
     {error, term()}.
 -export_type([url/0, conn/0, request_ret/0]).
 

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -344,17 +344,17 @@ stream_body(Pid) ->
 %%   - {hackney_response, Ref, {see_other, Location, Headers}} for 303 with POST
 %% AsyncMode: true (continuous) or once (one message at a time, use stream_next/1)
 -spec request_async(pid(), binary(), binary(), list(), binary() | iolist(), true | once) ->
-    {ok, reference()} | {error, term()}.
+    {ok, pid()} | {error, term()}.
 request_async(Pid, Method, Path, Headers, Body, AsyncMode) ->
     request_async(Pid, Method, Path, Headers, Body, AsyncMode, self(), false).
 
 -spec request_async(pid(), binary(), binary(), list(), binary() | iolist(), true | once, pid()) ->
-    {ok, reference()} | {error, term()}.
+    {ok, pid()} | {error, term()}.
 request_async(Pid, Method, Path, Headers, Body, AsyncMode, StreamTo) ->
     request_async(Pid, Method, Path, Headers, Body, AsyncMode, StreamTo, false).
 
 -spec request_async(pid(), binary(), binary(), list(), binary() | iolist(), true | once, pid(), boolean()) ->
-    {ok, reference()} | {error, term()}.
+    {ok, pid()} | {error, term()}.
 request_async(Pid, Method, Path, Headers, Body, AsyncMode, StreamTo, FollowRedirect) ->
     case valid_request_target(Path) of
         ok -> gen_statem:call(Pid, {request_async, Method, Path, Headers, Body, AsyncMode, StreamTo, FollowRedirect});
@@ -362,7 +362,7 @@ request_async(Pid, Method, Path, Headers, Body, AsyncMode, StreamTo, FollowRedir
     end.
 
 -spec request_async(pid(), binary(), binary(), list(), binary() | iolist(), true | once, pid(), boolean(), list()) ->
-    {ok, reference()} | {error, term()}.
+    {ok, pid()} | {error, term()}.
 request_async(Pid, Method, Path, Headers, Body, AsyncMode, StreamTo, FollowRedirect, ReqOpts) ->
     case valid_request_target(Path) of
         ok -> gen_statem:call(Pid, {request_async, Method, Path, Headers, Body, AsyncMode, StreamTo, FollowRedirect, ReqOpts});

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -141,7 +141,6 @@
     pool_pid :: pid() | undefined,  %% If set, connection is from a pool
 
     %% Request tracking
-    request_ref :: reference() | undefined,
     request_from :: {pid(), reference()} | undefined,
     method :: binary() | undefined,
     path :: binary() | undefined,

--- a/src/hackney_middleware.erl
+++ b/src/hackney_middleware.erl
@@ -49,7 +49,6 @@
 
 -type response() :: {ok, integer(), list(), binary()}
                   | {ok, integer(), list()}
-                  | {ok, reference()}
                   | {ok, pid()}
                   | {error, term()}.
 


### PR DESCRIPTION
Hey! Sorry for a PR without corresponding issue, but I think it is a small change and non controversial change.

During work on Tesla support, I've seen dialyzer complaining. In a couple of places there were leftover `reference` types instead of currently used `pid` types. This PR fixes that.