### PR TITLE
Fix/cross sign cert expired recovery

### DIFF
--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -82,8 +82,20 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),
+  %% Wrap ssl_verify_hostname to rewrite {bad_cert, cert_expired} to
+  %% {bad_cert, root_cert_expired} before delegating. OTP's cross-sign
+  %% recovery (ssl_certificate:find_cross_sign_root_paths/4) only runs
+  %% when path validation reports root_cert_expired; ssl_verify_hostname
+  %% returns cert_expired verbatim, which causes the handshake to fail
+  %% before recovery can trigger. Affected chains include Let's Encrypt
+  %% endpoints that present the ISRG Root X2 cross-signed by ISRG Root X1
+  %% (validity 2020-09-04 to 2025-09-15, now expired).
   VerifyFun = {
-    fun ssl_verify_hostname:verify_fun/3,
+    fun(_Cert, {bad_cert, cert_expired}, _State) ->
+            {fail, {bad_cert, root_cert_expired}};
+       (Cert, Event, State) ->
+            ssl_verify_hostname:verify_fun(Cert, Event, State)
+    end,
     [{check_hostname, Host1}]
    },
   SslOpts = [{verify, verify_peer},

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -82,14 +82,9 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),
-  %% Wrap ssl_verify_hostname to rewrite {bad_cert, cert_expired} to
-  %% {bad_cert, root_cert_expired} before delegating. OTP's cross-sign
-  %% recovery (ssl_certificate:find_cross_sign_root_paths/4) only runs
-  %% when path validation reports root_cert_expired; ssl_verify_hostname
-  %% returns cert_expired verbatim, which causes the handshake to fail
-  %% before recovery can trigger. Affected chains include Let's Encrypt
-  %% endpoints that present the ISRG Root X2 cross-signed by ISRG Root X1
-  %% (validity 2020-09-04 to 2025-09-15, now expired).
+  %% Rewrite cert_expired -> root_cert_expired so OTP's cross-sign recovery
+  %% (find_cross_sign_root_paths/4) triggers; ssl_verify_hostname returns
+  %% cert_expired verbatim, which bypasses it entirely.
   VerifyFun = {
     fun(_Cert, {bad_cert, cert_expired}, _State) ->
             {fail, {bad_cert, root_cert_expired}};

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -81,4 +81,5 @@ verify_fun_passes_through_other_bad_cert_test() ->
     %% Other bad_cert reasons must not be silently rewritten.
     Opts = hackney_ssl:check_hostname_opts("example.com"),
     {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
-    {fail, _} = VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState).
+    ?assertEqual({fail, {bad_cert, unknown_ca}},
+                 VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState)).

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -67,3 +67,18 @@ check_hostname_opts_test() ->
     Opts = hackney_ssl:check_hostname_opts("example.com"),
     ?assertEqual(verify_peer, proplists:get_value(verify, Opts)),
     ?assert(lists:keymember(cacerts, 1, Opts) orelse lists:keymember(cacertfile, 1, Opts)).
+
+verify_fun_rewrites_cert_expired_test() ->
+    %% cert_expired must be rewritten to root_cert_expired so OTP's
+    %% ssl_certificate:find_cross_sign_root_paths/4 recovery can trigger
+    %% (e.g. expired ISRG Root X2 cross-signed anchor in Let's Encrypt chains).
+    Opts = hackney_ssl:check_hostname_opts("example.com"),
+    {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
+    ?assertEqual({fail, {bad_cert, root_cert_expired}},
+                 VerifyFun(fake_cert, {bad_cert, cert_expired}, InitState)).
+
+verify_fun_passes_through_other_bad_cert_test() ->
+    %% Other bad_cert reasons must not be silently rewritten.
+    Opts = hackney_ssl:check_hostname_opts("example.com"),
+    {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
+    {fail, _} = VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState).


### PR DESCRIPTION
### Problem
This fix came out of a production incident. Our push notification service recently migrated to Let's Encrypt certificates. After the migration, all HTTPS calls made through hackney started failing with:

```
  {tls_alert, {certificate_expired, "TLS client: ... CLIENT ALERT: Fatal - Certificate Expired"}}
```
The leaf certificate was not expired. The issue is structural: Let's Encrypt chains include an ISRG Root X2 cross-signed by ISRG Root X1, whose validity period ran 2020-09-04 → 2025-09-15 and is now past.


### Root cause
  OTP ships recovery logic for exactly this scenario in `ssl_certificate:find_cross_sign_root_paths/4`. It triggers when path validation reports root_cert_expired: OTP searches the trust store for a cert with the same  public key as the expired root and, if found, re-validates the chain anchored at the still-valid self-signed copy.

The recovery never runs with hackney due to the following sequence:

1. OTP calls the :verify_fun with {bad_cert, cert_expired} for the expired cross-signed anchor.
2. Hackney's verify_fun is a direct reference to ssl_verify_hostname:verify_fun/3, which returns {fail, {bad_cert, cert_expired}} without any special treatment.
3. OTP receives `{fail, …}` and aborts the handshake immediately.
4. `find_cross_sign_root_paths/4` is never reached.

The OTP recovery only triggers on root_cert_expired, not cert_expired.

### Fix

Wrap `ssl_verify_hostname:verify_fun/3` in `check_hostname_opts/1` with a one-clause prefix that rewrites `{bad_cert, cert_expired}` to `{fail, {bad_cert, root_cert_expired}}`. All other events are delegated to `ssl_verify_hostname` unchanged, so hostname checking is unaffected.