### PR TITLE
Rewrite cert_expired to root_cert_expired for cross-sign recovery

### DIFF
--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -82,8 +82,20 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),
+  %% Wrap ssl_verify_hostname to rewrite {bad_cert, cert_expired} to
+  %% {bad_cert, root_cert_expired} before delegating. OTP's cross-sign
+  %% recovery (ssl_certificate:find_cross_sign_root_paths/4) only runs
+  %% when path validation reports root_cert_expired; ssl_verify_hostname
+  %% returns cert_expired verbatim, which causes the handshake to fail
+  %% before recovery can trigger. Affected chains include Let's Encrypt
+  %% endpoints that present the ISRG Root X2 cross-signed by ISRG Root X1
+  %% (validity 2020-09-04 to 2025-09-15, now expired).
   VerifyFun = {
-    fun ssl_verify_hostname:verify_fun/3,
+    fun(_Cert, {bad_cert, cert_expired}, _State) ->
+            {fail, {bad_cert, root_cert_expired}};
+       (Cert, Event, State) ->
+            ssl_verify_hostname:verify_fun(Cert, Event, State)
+    end,
     [{check_hostname, Host1}]
    },
   SslOpts = [{verify, verify_peer},

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -82,14 +82,9 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),
-  %% Wrap ssl_verify_hostname to rewrite {bad_cert, cert_expired} to
-  %% {bad_cert, root_cert_expired} before delegating. OTP's cross-sign
-  %% recovery (ssl_certificate:find_cross_sign_root_paths/4) only runs
-  %% when path validation reports root_cert_expired; ssl_verify_hostname
-  %% returns cert_expired verbatim, which causes the handshake to fail
-  %% before recovery can trigger. Affected chains include Let's Encrypt
-  %% endpoints that present the ISRG Root X2 cross-signed by ISRG Root X1
-  %% (validity 2020-09-04 to 2025-09-15, now expired).
+  %% Rewrite cert_expired -> root_cert_expired so OTP's cross-sign recovery
+  %% (find_cross_sign_root_paths/4) triggers; ssl_verify_hostname returns
+  %% cert_expired verbatim, which bypasses it entirely.
   VerifyFun = {
     fun(_Cert, {bad_cert, cert_expired}, _State) ->
             {fail, {bad_cert, root_cert_expired}};

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -81,4 +81,5 @@ verify_fun_passes_through_other_bad_cert_test() ->
     %% Other bad_cert reasons must not be silently rewritten.
     Opts = hackney_ssl:check_hostname_opts("example.com"),
     {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
-    {fail, _} = VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState).
+    ?assertEqual({fail, {bad_cert, unknown_ca}},
+                 VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState)).

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -67,3 +67,18 @@ check_hostname_opts_test() ->
     Opts = hackney_ssl:check_hostname_opts("example.com"),
     ?assertEqual(verify_peer, proplists:get_value(verify, Opts)),
     ?assert(lists:keymember(cacerts, 1, Opts) orelse lists:keymember(cacertfile, 1, Opts)).
+
+verify_fun_rewrites_cert_expired_test() ->
+    %% cert_expired must be rewritten to root_cert_expired so OTP's
+    %% ssl_certificate:find_cross_sign_root_paths/4 recovery can trigger
+    %% (e.g. expired ISRG Root X2 cross-signed anchor in Let's Encrypt chains).
+    Opts = hackney_ssl:check_hostname_opts("example.com"),
+    {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
+    ?assertEqual({fail, {bad_cert, root_cert_expired}},
+                 VerifyFun(fake_cert, {bad_cert, cert_expired}, InitState)).
+
+verify_fun_passes_through_other_bad_cert_test() ->
+    %% Other bad_cert reasons must not be silently rewritten.
+    Opts = hackney_ssl:check_hostname_opts("example.com"),
+    {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
+    {fail, _} = VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState).

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -83,3 +83,20 @@ verify_fun_passes_through_other_bad_cert_test() ->
     {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
     ?assertEqual({fail, {bad_cert, unknown_ca}},
                  VerifyFun(fake_cert, {bad_cert, unknown_ca}, InitState)).
+
+verify_fun_passes_through_valid_test() ->
+    %% Valid and extension events must delegate to ssl_verify_hostname
+    %% unchanged, so valid chains (including partial chains whose anchor is
+    %% accepted) still verify. Only cert_expired is rewritten.
+    Opts = hackney_ssl:check_hostname_opts("example.com"),
+    {VerifyFun, InitState} = proplists:get_value(verify_fun, Opts),
+    ?assertEqual({valid, InitState}, VerifyFun(fake_cert, valid, InitState)),
+    ?assertEqual({unknown, InitState},
+                 VerifyFun(fake_cert, {extension, fake_ext}, InitState)).
+
+partial_chain_preserved_test() ->
+    %% The cross-sign verify_fun change must not drop the partial_chain
+    %% option; partial certificate chains rely on it to pick a trusted anchor.
+    Opts = hackney_ssl:check_hostname_opts("example.com"),
+    PartialChain = proplists:get_value(partial_chain, Opts),
+    ?assert(is_function(PartialChain, 1)).


### PR DESCRIPTION
Rebase of #860 (by @mrnovalles) on master to get the ARM64 CI fix, with extra tests.

When the chain is anchored by an expired cross-signed root (Let's Encrypt ISRG Root X2 signed by the expired X1), OTP can recover by finding another valid root with the same key, but only when path validation reports `root_cert_expired`. hackney uses `ssl_verify_hostname`, which returns `cert_expired` and stops the handshake before the recovery runs.

The fix wraps the verify_fun to rewrite `cert_expired` into `root_cert_expired`. Other events go to `ssl_verify_hostname` as before.

Safe: if no valid alternative root exists, OTP fails again as `cert_expired`, so an expired leaf or intermediate still fails. Partial chains keep working: `partial_chain` stays, and `valid`, `valid_peer` and `extension` events pass through. Tests added for both.

Supersedes #860.
