### PR TITLE
Bump quic to 1.6.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
 
 {deps, [
         %% Pure Erlang QUIC + HTTP/3 stack
-        {quic, "1.6.1"},
+        {quic, "1.6.2"},
         %% Pure Erlang HTTP/2 stack
         {h2, "0.6.1"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API


### PR DESCRIPTION
Bump the quic dependency to 1.6.2.

1.6.2 adds cross-signed expired-root recovery to the QUIC TLS validation (`quic_cert`): an expired cross-signed root is dropped for a still-valid anchor with the same key, while an expired leaf or intermediate still fails. This gives HTTP/3 and WebTransport-over-HTTP/3 the same behaviour we already have for HTTP/1.1 and HTTP/2 (#863). No hackney code change needed.
