### PR TITLE
Bump h2 to 0.8.0 and webtransport to 0.3.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -55,9 +55,9 @@
         %% Pure Erlang QUIC + HTTP/3 stack
         {quic, "1.6.2"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "0.6.1"},
+        {h2, "0.8.0"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
-        {webtransport, "0.2.6"},
+        {webtransport, "0.3.0"},
         {idna, "~>7.1.0"},
         {mimerl, "~>1.4"},
         {certifi, "~>2.16.0"},


### PR DESCRIPTION
Bump h2 to 0.8.0 and webtransport to 0.3.0.

webtransport 0.3.0 requires h2 0.8.0 and quic 1.6.2, which hackney already pins (#864), so the versions line up. No hackney code change needed; xref, dialyzer and the h2/WebTransport/HTTP3 suites pass.
