### PR TITLE
Fix race in hackney_pool in hackney 4.2.1

### DIFF
--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -779,15 +779,20 @@ find_available(Key, Available) ->
             case is_process_alive(Pid) of
                 true ->
                     %% is_ready checks both state and socket health in one call
-                    case hackney_conn:is_ready(Pid) of
+                    try hackney_conn:is_ready(Pid) of
                         {ok, connected} -> {ok, Pid, Available2};
                         {ok, closed} ->
                             %% Connection closed, try reconnect
-                            case hackney_conn:connect(Pid) of
+                            try hackney_conn:connect(Pid) of
                                 ok -> {ok, Pid, Available2};
                                 _ -> find_available(Key, Available2)
+                            catch
+                                _:_ -> find_available(Key, Available2)
                             end;
                         _ -> find_available(Key, Available2)
+                    catch 
+                        _:_ -> 
+                            find_available(Key, Available2)
                     end;
                 false ->
                     find_available(Key, Available2)


### PR DESCRIPTION
In some cases on flaky network connection can die  after livness check with `noproc`, which crashes pool.

```
=CRASH REPORT==== 5-Jun-2026::19:26:39.618340 ===
  crasher:
    initial call: hackney_pool:init/1
    pid: <0.1206.0>
    registered_name: []
    exception exit: {noproc,{gen_statem,call,[<0.1427.0>,is_ready,infinity]}}
      in function  gen:do_call/4 (gen.erl:249)
      in call from gen_statem:call/3 (gen_statem.erl:3254)
      in call from hackney_pool:find_available/2 (./project/_build/default/lib/hackney/src/hackney_pool.erl:782)
      in call from hackney_pool:handle_call/3 (./project/_build/default/lib/hackney/src/hackney_pool.erl:487)
      in call from gen_server:try_handle_call/4 (gen_server.erl:2470)
      in call from gen_server:handle_msg/3 (gen_server.erl:2499)
    ancestors: [hackney_sup,<0.1012.0>]
    message_queue_len: 48
```

It looks like a race, where connection dies between calls to it. This fix tries to eliminate crash by forcing creation of new connection in case when no connection with given Pid already exists.