### PR TITLE
Key shared TLS connections and tickets by ssl options, opt-in HTTPS/1.1 pooling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,9 @@ unreleased
   HTTP/3 connections plus cached 0-RTT session tickets by the QUIC trust
   options. Requests with different `ssl_options` no longer share a multiplexed
   connection or resume each other's tickets.
+- The TLS options hash computed for every pooled HTTPS request is memoized in
+  a bounded ETS cache keyed by the pre-merge inputs and the relevant
+  application envs, skipping a sha256 over the full CA bundle on cache hits.
 
 4.2.3 - 2026-06-10
 ------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,14 @@ unreleased
   options and is reused only on an exact match, skipping the TLS handshake on
   follow-up requests. The default is unchanged: SSL connections are closed at
   checkin. (#872)
+- TLS 1.3 session resumption for requests using hackney's default TLS config.
+  When no `ssl_options` are passed, connections are opened with
+  `{session_tickets, auto}` so fresh connections to the same server resume
+  the session instead of paying a full handshake. Disable with the
+  `tls_session_resumption` application env (default true). Requests with
+  custom `ssl_options` deliberately get no resumption: OTP's ticket store is
+  node-global and a resumed handshake skips certificate validation, so only
+  the shared default trust config may use it (trust isolation). (#872)
 
 ### Changed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+unreleased
+----------
+
+### Added
+
+- Opt-in pooling of HTTPS/1.1 connections. With `{ssl_pooling, true}` (request
+  option, or the `ssl_pooling` application env; default false) an upgraded SSL
+  connection returns to the pool keyed by the hash of its effective TLS
+  options and is reused only on an exact match, skipping the TLS handshake on
+  follow-up requests. The default is unchanged: SSL connections are closed at
+  checkin. (#872)
+
+### Changed
+
+- Shared HTTP/2 connections are keyed by the effective TLS options, and shared
+  HTTP/3 connections plus cached 0-RTT session tickets by the QUIC trust
+  options. Requests with different `ssl_options` no longer share a multiplexed
+  connection or resume each other's tickets.
+
 4.2.3 - 2026-06-10
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ TLS options, so only requests with identical `ssl_options` reuse them:
 hackney:get(URL, [], <<>>, [{ssl_pooling, true}]).
 ```
 
+Requests using hackney's default TLS config (no `ssl_options` passed) also
+enable TLS 1.3 session resumption (`{session_tickets, auto}`), so fresh
+connections to a recently contacted server skip the full handshake. Set the
+`tls_session_resumption` application env to `false` to turn this off.
+Requests with custom `ssl_options` never use resumption: the OTP ticket
+store is shared node-wide and a resumed session skips certificate
+validation, so it is reserved for the identical default trust config.
+
 ### Streaming
 
 Stream request bodies for uploads:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ hackney:get(URL, [], <<>>, [{pool, api_pool}]).
 hackney:get(URL, [], <<>>, [{pool, false}]).
 ```
 
+By default only plain TCP connections stay in the pool: an HTTPS request
+upgrades a pooled TCP connection and the SSL connection is closed after use.
+Set `{ssl_pooling, true}` per request (or the `ssl_pooling` application env)
+to also pool HTTPS/1.1 connections. Pooled SSL connections are keyed by their
+TLS options, so only requests with identical `ssl_options` reuse them:
+
+```erlang
+%% Reuse HTTPS/1.1 connections, skipping the TLS handshake
+hackney:get(URL, [], <<>>, [{ssl_pooling, true}]).
+```
+
 ### Streaming
 
 Stream request bodies for uploads:

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -215,13 +215,20 @@ effective_ssl_opts(Host, Options) ->
 
 %% @private Try to get or establish an HTTP/3 connection
 try_h3_connection(Host, Port, Transport, Options, PoolHandler) ->
+  %% Hash the QUIC trust projection once; it keys both the shared H3
+  %% connection and the 0-RTT ticket cache so requests with differing
+  %% trust configs never share either.
+  ConnectOpts = proplists:get_value(connect_options, Options, []),
+  SslOpts = proplists:get_value(ssl_options, Options, []),
+  K3 = hackney_ssl:h3_options_key(ConnectOpts, SslOpts),
+  Options2 = [{h3_tls_key, K3} | Options],
   %% Check if HTTP/3 is blocked for this host (negative cache)
   case hackney_altsvc:is_h3_blocked(Host, Port) of
     true ->
       false;
     false ->
       %% Check if we have an existing HTTP/3 connection
-      case PoolHandler:checkout_h3(Host, Port, Transport, Options) of
+      case PoolHandler:checkout_h3(Host, Port, Transport, Options2) of
         {ok, H3Pid} ->
           %% Verify connection is actually in connected state
           case hackney_conn:get_state(H3Pid) of
@@ -229,21 +236,21 @@ try_h3_connection(Host, Port, Transport, Options, PoolHandler) ->
               {ok, H3Pid};
             _ ->
               %% Connection not ready, unregister and try new connection
-              PoolHandler:unregister_h3(H3Pid, Options),
-              try_new_h3_connection(Host, Port, Transport, Options, PoolHandler)
+              PoolHandler:unregister_h3(H3Pid, Options2),
+              try_new_h3_connection(Host, Port, Transport, Options2, PoolHandler)
           end;
         none ->
           %% Check Alt-Svc cache for known HTTP/3 endpoint
           case hackney_altsvc:lookup(Host, Port) of
             {ok, h3, H3Port} ->
               %% Alt-Svc says HTTP/3 is available, try connecting
-              try_new_h3_connection(Host, H3Port, Transport, Options, PoolHandler);
+              try_new_h3_connection(Host, H3Port, Transport, Options2, PoolHandler);
             none ->
               %% No Alt-Svc cached, only try H3 if explicitly requested
               case lists:member(http3, proplists:get_value(protocols, Options, [])) of
                 true ->
                   %% User explicitly wants HTTP/3, try it
-                  try_new_h3_connection(Host, Port, Transport, Options, PoolHandler);
+                  try_new_h3_connection(Host, Port, Transport, Options2, PoolHandler);
                 false ->
                   false
               end

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -164,13 +164,20 @@ connect_pool(Transport, Host, Port, Options) ->
   %% For SSL connections, try multiplexed protocols (HTTP/3 first, then HTTP/2)
   case Transport of
     hackney_ssl ->
+      %% Compute the exact TLS handshake options once; their hash keys the
+      %% shared HTTP/2 connection so requests with different ssl_options
+      %% never share a connection. FinalSslOpts is passed alongside Options
+      %% (not inside it) to keep the large CA material out of the pool state.
+      FinalSslOpts = effective_ssl_opts(Host, Options),
+      TlsKey = hackney_ssl:options_key(FinalSslOpts),
+      Options2 = [{tls_key, TlsKey} | Options],
       %% Check HTTP/3 first if allowed
       case H3Allowed andalso try_h3_connection(Host, Port, Transport, Options, PoolHandler) of
         {ok, H3Pid} ->
           {ok, H3Pid};
         _ when H2Allowed ->
           %% Try HTTP/2 multiplexing
-          case PoolHandler:checkout_h2(Host, Port, Transport, Options) of
+          case PoolHandler:checkout_h2(Host, Port, Transport, Options2) of
             {ok, H2Pid} ->
               %% Verify connection is actually in connected state
               %% (OTP 28 on FreeBSD may have timing issues with SSL connections)
@@ -179,20 +186,32 @@ connect_pool(Transport, Host, Port, Options) ->
                           {ok, H2Pid};
                 _ ->
                   %% Connection not ready, unregister and create new
-                  PoolHandler:unregister_h2(H2Pid, Options),
-                  connect_pool_new(Transport, Host, Port, Options, PoolHandler)
+                  PoolHandler:unregister_h2(H2Pid, Options2),
+                  connect_pool_new(Transport, Host, Port, Options2, FinalSslOpts, PoolHandler)
               end;
             none ->
-              connect_pool_new(Transport, Host, Port, Options, PoolHandler)
+              connect_pool_new(Transport, Host, Port, Options2, FinalSslOpts, PoolHandler)
           end;
         _ ->
           %% No multiplexed protocols allowed or available
-          connect_pool_new(Transport, Host, Port, Options, PoolHandler)
+          connect_pool_new(Transport, Host, Port, Options2, FinalSslOpts, PoolHandler)
       end;
     _ ->
       %% Non-SSL, use normal pool
-      connect_pool_new(Transport, Host, Port, Options, PoolHandler)
+      connect_pool_new(Transport, Host, Port, Options, undefined, PoolHandler)
   end.
+
+%% @private Build the exact TLS handshake options for a pooled SSL request.
+%% Single source of truth: replicates what maybe_upgrade_ssl used to build
+%% inline, including the optional protocols entry for ALPN.
+effective_ssl_opts(Host, Options) ->
+  SslOpts = proplists:get_value(ssl_options, Options, []),
+  SslOpts2 = case proplists:get_value(protocols, Options, undefined) of
+    undefined -> SslOpts;
+    Protocols -> [{protocols, Protocols} | SslOpts]
+  end,
+  ConnectOpts = proplists:get_value(connect_options, Options, []),
+  hackney_ssl:effective_opts(Host, SslOpts2, ConnectOpts).
 
 %% @private Try to get or establish an HTTP/3 connection
 try_h3_connection(Host, Port, Transport, Options, PoolHandler) ->
@@ -309,7 +328,7 @@ maybe_inject_h3_session(ConnectOpts, SslOpts, Host, Port, Transport, Options, Po
       end
   end.
 
-connect_pool_new(Transport, Host, Port, Options, PoolHandler) ->
+connect_pool_new(Transport, Host, Port, Options, FinalSslOpts, PoolHandler) ->
   MaxPerHost = proplists:get_value(max_per_host, Options, 50),
   CheckoutTimeout = proplists:get_value(checkout_timeout, Options,
                       proplists:get_value(connect_timeout, Options, 8000)),
@@ -322,7 +341,7 @@ connect_pool_new(Transport, Host, Port, Options, PoolHandler) ->
       case PoolHandler:checkout(Host, Port, hackney_tcp, Options) of
         {ok, _PoolRef, ConnPid} ->
           %% Got TCP connection - upgrade to SSL if needed
-          case maybe_upgrade_ssl(Transport, ConnPid, Host, Options) of
+          case maybe_upgrade_ssl(Transport, ConnPid, FinalSslOpts) of
             ok ->
               %% Check if HTTP/2 was negotiated, register for multiplexing
               maybe_register_h2(ConnPid, Host, Port, Transport, Options, PoolHandler),
@@ -359,15 +378,10 @@ maybe_register_h2(ConnPid, Host, Port, Transport, Options, PoolHandler) ->
       ok
   end.
 
-%% @private Upgrade TCP connection to SSL if needed
-maybe_upgrade_ssl(hackney_ssl, ConnPid, Host, Options) ->
-  SslOpts = proplists:get_value(ssl_options, Options, []),
-  %% Add protocols option for ALPN negotiation if specified
-  Protocols = proplists:get_value(protocols, Options, undefined),
-  SslOpts2 = case Protocols of
-    undefined -> SslOpts;
-    _ -> [{protocols, Protocols} | SslOpts]
-  end,
+%% @private Upgrade TCP connection to SSL if needed.
+%% FinalSslOpts is precomputed by effective_ssl_opts/2 so the handshake uses
+%% exactly the options hashed into the pool tls_key.
+maybe_upgrade_ssl(hackney_ssl, ConnPid, FinalSslOpts) ->
   %% Check if connection is already SSL (e.g., reused SSL connection)
   try hackney_conn:is_upgraded_ssl(ConnPid) of
     true ->
@@ -375,13 +389,13 @@ maybe_upgrade_ssl(hackney_ssl, ConnPid, Host, Options) ->
       ok;
     _ ->
       %% Upgrade TCP to SSL with ALPN
-      hackney_conn:upgrade_to_ssl(ConnPid, [{server_name_indication, Host} | SslOpts2])
+      hackney_conn:upgrade_to_ssl(ConnPid, FinalSslOpts, #{final => true})
   catch
     _:_ ->
       %% Connection terminated, attempt upgrade anyway
-      hackney_conn:upgrade_to_ssl(ConnPid, [{server_name_indication, Host} | SslOpts2])
+      hackney_conn:upgrade_to_ssl(ConnPid, FinalSslOpts, #{final => true})
   end;
-maybe_upgrade_ssl(_, _ConnPid, _Host, _Options) ->
+maybe_upgrade_ssl(_, _ConnPid, _FinalSslOpts) ->
   %% Not SSL, no upgrade needed
   ok.
 

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -168,8 +168,7 @@ connect_pool(Transport, Host, Port, Options) ->
       %% shared HTTP/2 connection so requests with different ssl_options
       %% never share a connection. FinalSslOpts is passed alongside Options
       %% (not inside it) to keep the large CA material out of the pool state.
-      FinalSslOpts = effective_ssl_opts(Host, Options),
-      TlsKey = hackney_ssl:options_key(FinalSslOpts),
+      {FinalSslOpts, TlsKey} = effective_ssl_opts(Host, Options),
       Options2 = [{tls_key, TlsKey} | Options],
       %% Check HTTP/3 first if allowed
       case H3Allowed andalso try_h3_connection(Host, Port, Transport, Options, PoolHandler) of
@@ -201,9 +200,10 @@ connect_pool(Transport, Host, Port, Options) ->
       connect_pool_new(Transport, Host, Port, Options, undefined, PoolHandler)
   end.
 
-%% @private Build the exact TLS handshake options for a pooled SSL request.
-%% Single source of truth: replicates what maybe_upgrade_ssl used to build
-%% inline, including the optional protocols entry for ALPN.
+%% @private Build the exact TLS handshake options for a pooled SSL request,
+%% plus their memoized pool key hash. Single source of truth: replicates
+%% what maybe_upgrade_ssl used to build inline, including the optional
+%% protocols entry for ALPN.
 effective_ssl_opts(Host, Options) ->
   SslOpts = proplists:get_value(ssl_options, Options, []),
   SslOpts2 = case proplists:get_value(protocols, Options, undefined) of
@@ -211,7 +211,7 @@ effective_ssl_opts(Host, Options) ->
     Protocols -> [{protocols, Protocols} | SslOpts]
   end,
   ConnectOpts = proplists:get_value(connect_options, Options, []),
-  hackney_ssl:effective_opts(Host, SslOpts2, ConnectOpts).
+  hackney_ssl:effective_opts_and_key(Host, SslOpts2, ConnectOpts).
 
 %% @private Try to get or establish an HTTP/3 connection
 try_h3_connection(Host, Port, Transport, Options, PoolHandler) ->

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -344,28 +344,63 @@ connect_pool_new(Transport, Host, Port, Options, FinalSslOpts, PoolHandler) ->
   case hackney_load_regulation:acquire(Host, Port, MaxPerHost, CheckoutTimeout) of
     ok ->
       %% Slot acquired - now get connection from pool
-      %% Always checkout as TCP - pool only stores TCP connections
-      case PoolHandler:checkout(Host, Port, hackney_tcp, Options) of
-        {ok, _PoolRef, ConnPid} ->
-          %% Got TCP connection - upgrade to SSL if needed
-          case maybe_upgrade_ssl(Transport, ConnPid, FinalSslOpts) of
-            ok ->
-              %% Check if HTTP/2 was negotiated, register for multiplexing
-              maybe_register_h2(ConnPid, Host, Port, Transport, Options, PoolHandler),
+      SslPooling = proplists:get_value(ssl_pooling, Options,
+                     hackney_app:get_app_env(ssl_pooling, false)),
+      case Transport =:= hackney_ssl andalso SslPooling =:= true
+           andalso erlang:function_exported(PoolHandler, checkout_ssl, 4) of
+        true ->
+          %% Opt-in ssl_pooling: pooled HTTPS/1.1 connections are reused on
+          %% an exact match of the TLS options hash (tls_key in Options)
+          connect_pool_ssl(Transport, Host, Port, Options, FinalSslOpts, PoolHandler);
+        false ->
+          %% Always checkout as TCP - pool only stores TCP connections
+          case PoolHandler:checkout(Host, Port, hackney_tcp, Options) of
+            {ok, _PoolRef, ConnPid} ->
+              %% Got TCP connection - upgrade to SSL if needed
+              case maybe_upgrade_ssl(Transport, ConnPid, FinalSslOpts) of
+                ok ->
+                  %% Check if HTTP/2 was negotiated, register for multiplexing
+                  maybe_register_h2(ConnPid, Host, Port, Transport, Options, PoolHandler),
                   {ok, ConnPid};
+                {error, Reason} ->
+                  %% Upgrade failed - release slot and close connection
+                  hackney_load_regulation:release(Host, Port),
+                  stop_conn(ConnPid),
+                  {error, Reason}
+              end;
             {error, Reason} ->
-              %% Upgrade failed - release slot and close connection
+              %% Checkout failed - release slot
               hackney_load_regulation:release(Host, Port),
-              stop_conn(ConnPid),
               {error, Reason}
-          end;
-        {error, Reason} ->
-          %% Checkout failed - release slot
-          hackney_load_regulation:release(Host, Port),
-          {error, Reason}
+          end
       end;
     {error, timeout} ->
       {error, checkout_timeout}
+  end.
+
+%% @private SSL-pooling checkout. A `ready' conn is an already-upgraded
+%% HTTPS/1.1 connection reused on an exact tls_key match; it was registered
+%% for h2 at creation if applicable, so it is not re-registered here. A
+%% `needs_upgrade' conn is a TCP connection upgraded with pool_ssl so it can
+%% return to the pool at checkin.
+connect_pool_ssl(Transport, Host, Port, Options, FinalSslOpts, PoolHandler) ->
+  case PoolHandler:checkout_ssl(Host, Port, Transport, Options) of
+    {ok, _PoolRef, ConnPid, ready} ->
+      {ok, ConnPid};
+    {ok, _PoolRef, ConnPid, needs_upgrade} ->
+      case hackney_conn:upgrade_to_ssl(ConnPid, FinalSslOpts,
+                                       #{final => true, pool_ssl => true}) of
+        ok ->
+          maybe_register_h2(ConnPid, Host, Port, Transport, Options, PoolHandler),
+          {ok, ConnPid};
+        {error, Reason} ->
+          hackney_load_regulation:release(Host, Port),
+          stop_conn(ConnPid),
+          {error, Reason}
+      end;
+    {error, Reason} ->
+      hackney_load_regulation:release(Host, Port),
+      {error, Reason}
   end.
 
 %% @private Register HTTP/2 connection for multiplexing if applicable

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -2458,11 +2458,26 @@ do_tcp_connect(From, Data) ->
     TransportOpts = proplists:delete(protocols, ConnectOpts),
     Opts = case Transport of
         hackney_ssl ->
-            %% Use ssl_opts/2 to properly merge defaults with user options
-            %% (handles cacertfile vs cacerts correctly)
-            MergedSslOpts = hackney_ssl:ssl_opts(Host, [{ssl_options, SslOpts0}]),
-            AlpnOpts = hackney_ssl:alpn_opts(ConnectOpts),
-            FinalSslOpts = hackney_util:merge_opts(MergedSslOpts, AlpnOpts),
+            FinalSslOpts = case SslOpts0 of
+                [] ->
+                    %% Default TLS config: build the handshake options like the
+                    %% pooled path does, which also makes the connection
+                    %% eligible for TLS 1.3 session resumption.
+                    SslOpts1 = case proplists:get_value(protocols, ConnectOpts) of
+                        undefined -> [];
+                        Protocols -> [{protocols, Protocols}]
+                    end,
+                    hackney_ssl:effective_opts(Host, SslOpts1, ConnectOpts);
+                _ ->
+                    %% Keep the legacy build for custom ssl_options: routing
+                    %% them through effective_opts would change the
+                    %% hostname-verification target for a user-supplied
+                    %% server_name_indication (merge_ssl_opts takes the first
+                    %% SNI occurrence).
+                    MergedSslOpts = hackney_ssl:ssl_opts(Host, [{ssl_options, SslOpts0}]),
+                    AlpnOpts = hackney_ssl:alpn_opts(ConnectOpts),
+                    hackney_util:merge_opts(MergedSslOpts, AlpnOpts)
+            end,
             TransportOpts ++ [{ssl_options, FinalSslOpts}];
         _ -> TransportOpts
     end,

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -71,6 +71,7 @@
     is_ready/1,
     %% SSL upgrade
     upgrade_to_ssl/2,
+    upgrade_to_ssl/3,
     is_upgraded_ssl/1,
     %% Reuse control
     is_no_reuse/1,
@@ -519,7 +520,16 @@ is_ready(Pid) ->
 %% NOT be returned to the pool (SSL connections are not pooled for security).
 -spec upgrade_to_ssl(pid(), list()) -> ok | {error, term()}.
 upgrade_to_ssl(Pid, SslOpts) ->
-    gen_statem:call(Pid, {upgrade_to_ssl, SslOpts}, infinity).
+    upgrade_to_ssl(Pid, SslOpts, #{final => false}).
+
+%% @doc Upgrade a TCP connection to SSL with explicit upgrade options.
+%% With `#{final => true}' SslOpts is handed to `ssl:connect/2' as-is
+%% (the caller computed it via hackney_ssl:effective_opts/3); the default
+%% `#{final => false}' keeps the legacy behavior of merging defaults and
+%% ALPN options inside the connection process.
+-spec upgrade_to_ssl(pid(), list(), map()) -> ok | {error, term()}.
+upgrade_to_ssl(Pid, SslOpts, UpgradeOpts) when is_map(UpgradeOpts) ->
+    gen_statem:call(Pid, {upgrade_to_ssl, SslOpts, UpgradeOpts}, infinity).
 
 %% @doc Check if this connection was upgraded from TCP to SSL.
 %% Upgraded connections should be closed after use, not returned to pool.
@@ -808,21 +818,29 @@ connected({call, From}, is_ready, #conn_data{transport = Transport, socket = Soc
             end
     end;
 
-connected({call, From}, {upgrade_to_ssl, _SslOpts}, #conn_data{transport = hackney_ssl} = _Data) ->
+connected({call, From}, {upgrade_to_ssl, _SslOpts, _UpgradeOpts}, #conn_data{transport = hackney_ssl} = _Data) ->
     %% Already SSL - no upgrade needed
     {keep_state_and_data, [{reply, From, ok}]};
-connected({call, From}, {upgrade_to_ssl, SslOpts}, #conn_data{socket = Socket, host = Host, connect_options = ConnectOpts} = Data) ->
+connected({call, From}, {upgrade_to_ssl, SslOpts, UpgradeOpts}, #conn_data{socket = Socket, host = Host, connect_options = ConnectOpts} = Data) ->
     %% Upgrade TCP socket to SSL (e.g., after CONNECT proxy tunnel)
-    %% Use ssl_opts/2 to properly merge defaults with user options
-    %% (handles cacertfile vs cacerts correctly)
-    MergedSslOpts = hackney_ssl:ssl_opts(Host, [{ssl_options, SslOpts}]),
-    %% Add ALPN options for HTTP/2 negotiation
-    %% Check both SslOpts (from upgrade call) and ConnectOpts (from initial config)
-    AlpnOpts = case hackney_ssl:alpn_opts(SslOpts) of
-        [] -> hackney_ssl:alpn_opts(ConnectOpts);
-        Opts -> Opts
+    FinalSslOpts = case maps:get(final, UpgradeOpts, false) of
+        true ->
+            %% Caller computed the exact handshake options with
+            %% hackney_ssl:effective_opts/3; use them as-is so the pool
+            %% tls_key hash matches what the handshake actually used.
+            SslOpts;
+        false ->
+            %% Use ssl_opts/2 to properly merge defaults with user options
+            %% (handles cacertfile vs cacerts correctly)
+            MergedSslOpts = hackney_ssl:ssl_opts(Host, [{ssl_options, SslOpts}]),
+            %% Add ALPN options for HTTP/2 negotiation
+            %% Check both SslOpts (from upgrade call) and ConnectOpts (from initial config)
+            AlpnOpts = case hackney_ssl:alpn_opts(SslOpts) of
+                [] -> hackney_ssl:alpn_opts(ConnectOpts);
+                Opts -> Opts
+            end,
+            hackney_util:merge_opts(MergedSslOpts, AlpnOpts)
     end,
-    FinalSslOpts = hackney_util:merge_opts(MergedSslOpts, AlpnOpts),
     case ssl:connect(Socket, FinalSslOpts) of
         {ok, SslSocket} ->
             %% Detect negotiated protocol

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -3198,11 +3198,17 @@ maybe_store_h3_session(_Ticket, #conn_data{pool_handler = undefined}) ->
     ok;
 maybe_store_h3_session(Ticket, #conn_data{pool_handler = PoolHandler, host = Host,
                                           port = Port, transport = Transport,
-                                          pool_name = PoolName}) ->
+                                          pool_name = PoolName,
+                                          connect_options = ConnectOpts,
+                                          ssl_options = SslOpts}) ->
     case erlang:function_exported(PoolHandler, store_h3_session, 5) of
         true ->
+            %% connect_options may carry the injected per-resumption
+            %% session_ticket; h3_options_key ignores it, so this key matches
+            %% the one the request side computes without the ticket.
+            K3 = hackney_ssl:h3_options_key(ConnectOpts, SslOpts),
             try PoolHandler:store_h3_session(Host, Port, Transport, Ticket,
-                                             [{pool, PoolName}])
+                                             [{pool, PoolName}, {h3_tls_key, K3}])
             catch _:_ -> ok
             end,
             ok;
@@ -3215,11 +3221,14 @@ maybe_delete_h3_session(#conn_data{pool_handler = undefined}) ->
     ok;
 maybe_delete_h3_session(#conn_data{pool_handler = PoolHandler, host = Host,
                                    port = Port, transport = Transport,
-                                   pool_name = PoolName}) ->
+                                   pool_name = PoolName,
+                                   connect_options = ConnectOpts,
+                                   ssl_options = SslOpts}) ->
     case erlang:function_exported(PoolHandler, delete_h3_session, 4) of
         true ->
+            K3 = hackney_ssl:h3_options_key(ConnectOpts, SslOpts),
             try PoolHandler:delete_h3_session(Host, Port, Transport,
-                                              [{pool, PoolName}])
+                                              [{pool, PoolName}, {h3_tls_key, K3}])
             catch _:_ -> ok
             end,
             ok;

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -75,6 +75,7 @@
     is_upgraded_ssl/1,
     %% Reuse control
     is_no_reuse/1,
+    checkin_info/1,
     %% Owner management
     set_owner/2,
     set_owner_async/2,
@@ -167,8 +168,12 @@
     follow_redirect = false :: boolean(),
 
     %% SSL upgrade tracking - set when TCP connection is upgraded to SSL
-    %% Upgraded connections should NOT be returned to pool
+    %% Upgraded connections are not returned to the pool unless pool_ssl is set
     upgraded_ssl = false :: boolean(),
+
+    %% Set with upgraded_ssl when the caller opted into ssl_pooling, allowing
+    %% the pool to keep the upgraded HTTPS/1.1 connection instead of closing it
+    pool_ssl = false :: boolean(),
 
     %% No-reuse flag - set for connections that should never be pooled
     %% (e.g., SOCKS5 proxy connections which establish per-request tunnels)
@@ -526,7 +531,8 @@ upgrade_to_ssl(Pid, SslOpts) ->
 %% With `#{final => true}' SslOpts is handed to `ssl:connect/2' as-is
 %% (the caller computed it via hackney_ssl:effective_opts/3); the default
 %% `#{final => false}' keeps the legacy behavior of merging defaults and
-%% ALPN options inside the connection process.
+%% ALPN options inside the connection process. `#{pool_ssl => true}' marks
+%% the upgraded connection as poolable again (ssl_pooling opt-in).
 -spec upgrade_to_ssl(pid(), list(), map()) -> ok | {error, term()}.
 upgrade_to_ssl(Pid, SslOpts, UpgradeOpts) when is_map(UpgradeOpts) ->
     gen_statem:call(Pid, {upgrade_to_ssl, SslOpts, UpgradeOpts}, infinity).
@@ -542,6 +548,14 @@ is_upgraded_ssl(Pid) ->
 -spec is_no_reuse(pid()) -> boolean().
 is_no_reuse(Pid) ->
     gen_statem:call(Pid, is_no_reuse).
+
+%% @doc Get the flags the pool needs for its checkin decision in one call:
+%% whether the connection was SSL upgraded, opted into SSL pooling, must not
+%% be reused (proxy tunnels), and the negotiated protocol.
+-spec checkin_info(pid()) -> #{upgraded_ssl := boolean(), no_reuse := boolean(),
+                               pool_ssl := boolean(), protocol := atom()}.
+checkin_info(Pid) ->
+    gen_statem:call(Pid, checkin_info).
 
 %% @doc Get the negotiated protocol for this connection.
 %% Returns http1, http2, or http3 based on ALPN negotiation (SSL connections),
@@ -849,7 +863,8 @@ connected({call, From}, {upgrade_to_ssl, SslOpts, UpgradeOpts}, #conn_data{socke
             NewData = Data#conn_data{
                 transport = hackney_ssl,
                 socket = SslSocket,
-                upgraded_ssl = true,  % Mark as upgraded - should NOT return to pool
+                upgraded_ssl = true,  % Mark as upgraded - pooled again only with pool_ssl
+                pool_ssl = maps:get(pool_ssl, UpgradeOpts, false),
                 protocol = Protocol
             },
             %% Initialize HTTP/2 if negotiated
@@ -868,6 +883,9 @@ connected({call, From}, is_upgraded_ssl, #conn_data{upgraded_ssl = Upgraded}) ->
 
 connected({call, From}, is_no_reuse, #conn_data{no_reuse = NoReuse}) ->
     {keep_state_and_data, [{reply, From, NoReuse}]};
+
+connected({call, From}, checkin_info, Data) ->
+    {keep_state_and_data, [{reply, From, checkin_info_map(Data)}]};
 
 connected({call, From}, {request, Method, Path, Headers, Body, ReqOpts}, #conn_data{protocol = http2} = Data) ->
     %% HTTP/2 request - use h2_machine (1xx not applicable for HTTP/2)
@@ -1670,6 +1688,9 @@ handle_common({call, From}, is_upgraded_ssl, _State, #conn_data{upgraded_ssl = U
 handle_common({call, From}, is_no_reuse, _State, #conn_data{no_reuse = NoReuse}) ->
     {keep_state_and_data, [{reply, From, NoReuse}]};
 
+handle_common({call, From}, checkin_info, _State, Data) ->
+    {keep_state_and_data, [{reply, From, checkin_info_map(Data)}]};
+
 handle_common({call, From}, get_protocol, _State, #conn_data{protocol = Protocol}) ->
     {keep_state_and_data, [{reply, From, Protocol}]};
 
@@ -2267,12 +2288,23 @@ notify_pool_available(#conn_data{pool_pid = PoolPid}) ->
 %% @private Notify pool that connection is available for reuse (sync)
 %% This ensures the pool has processed the checkin before returning.
 %% We pass a "should close" flag to avoid deadlock (pool can't call back to us).
-%% The flag is true if connection was SSL upgraded or is a proxy tunnel (no_reuse).
+%% The flag is true for proxy tunnels (no_reuse), for SSL upgrades unless the
+%% caller opted into ssl_pooling, and for non HTTP/1.1 conns (multiplexed
+%% conns never enter the pool's available set).
 notify_pool_available_sync(#conn_data{pool_pid = undefined}) ->
     ok;
-notify_pool_available_sync(#conn_data{pool_pid = PoolPid, upgraded_ssl = UpgradedSsl, no_reuse = NoReuse}) ->
-    ShouldClose = UpgradedSsl orelse NoReuse,
+notify_pool_available_sync(#conn_data{pool_pid = PoolPid, upgraded_ssl = UpgradedSsl,
+                                      no_reuse = NoReuse, pool_ssl = PoolSsl,
+                                      protocol = Protocol}) ->
+    ShouldClose = NoReuse orelse (UpgradedSsl andalso not PoolSsl)
+        orelse Protocol =/= http1,
     gen_server:call(PoolPid, {checkin_sync, self(), ShouldClose}, 5000).
+
+%% @private Flags for the pool's checkin decision, see checkin_info/1.
+checkin_info_map(#conn_data{upgraded_ssl = UpgradedSsl, no_reuse = NoReuse,
+                            pool_ssl = PoolSsl, protocol = Protocol}) ->
+    #{upgraded_ssl => UpgradedSsl, no_reuse => NoReuse,
+      pool_ssl => PoolSsl, protocol => Protocol}.
 
 %% @private Start an async request
 do_request_async(From, Method, Path, Headers, Body, AsyncMode, StreamTo, FollowRedirect, Data) ->

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -18,6 +18,7 @@
 %% PUBLIC API
 -export([start/0,
          checkout/4,
+         checkout_ssl/4,
          checkin/2]).
 
 %% HTTP/2 connection pooling
@@ -84,7 +85,7 @@
     %% These connections are shared across callers (not checked out exclusively)
     h3_connections = #{},
     %% HTTP/3 0-RTT/resumption session tickets: #{Key => Ticket} keyed by
-    %% {Host, Port, Transport}. Replayed on the next connect to resume.
+    %% h3_connection_key/4. Replayed on the next connect to resume.
     h3_sessions = #{}
 }).
 
@@ -127,6 +128,45 @@ do_checkout(Requester, Host, Port, Transport, Opts) ->
             %% Return pool info for later checkin
             PoolInfo = {PoolName, Key, Pool, Transport},
             {ok, PoolInfo, Pid};
+        {error, _} = Error ->
+            Error;
+        {'EXIT', {timeout, _}} ->
+            {error, checkout_timeout}
+    end.
+
+%% @doc Checkout a connection for an HTTPS request with SSL pooling enabled.
+%% Reuses a pooled upgraded HTTPS/1.1 connection when the hash of its TLS
+%% options (`tls_key' in Options) matches exactly, returning `ready'.
+%% Otherwise a TCP connection is handed out as `needs_upgrade' and the
+%% caller performs the TLS upgrade.
+-spec checkout_ssl(Host :: string(), Port :: non_neg_integer(),
+                   Transport :: module(), Options :: list()) ->
+    {ok, term(), pid(), ready | needs_upgrade} | {error, term()}.
+checkout_ssl(Host, Port, Transport, Options) ->
+    Requester = self(),
+    try
+        do_checkout_ssl(Requester, Host, Port, Transport, Options)
+    catch
+        exit:{timeout, _} ->
+            ?report_trace("pool: checkout_ssl timeout", []),
+            {error, checkout_timeout};
+        _:Error ->
+            ?report_trace("pool: checkout_ssl failure", [{error, Error}]),
+            {error, checkout_failure}
+    end.
+
+do_checkout_ssl(Requester, Host, Port, Transport, Opts) ->
+    ConnectTimeout = proplists:get_value(connect_timeout, Opts, 8000),
+    CheckoutTimeout = proplists:get_value(checkout_timeout, Opts, ConnectTimeout),
+    PoolName = proplists:get_value(pool, Opts, default),
+    Pool = find_pool(PoolName, Opts),
+    TlsKey = proplists:get_value(tls_key, Opts, default),
+    SslKey = connection_key(Host, Port, Transport, TlsKey),
+
+    case gen_server:call(Pool, {checkout_ssl, SslKey, Requester, Opts}, CheckoutTimeout) of
+        {ok, Pid, ConnState} ->
+            PoolInfo = {PoolName, SslKey, Pool, Transport},
+            {ok, PoolInfo, Pid, ConnState};
         {error, _} = Error ->
             Error;
         {'EXIT', {timeout, _}} ->
@@ -308,7 +348,9 @@ count(Name) ->
         Pid -> gen_server:call(Pid, count)
     end.
 
-%% @doc get the number of connections in the pool for `{Host, Port, Transport}'
+%% @doc get the number of connections in the pool for a key. A legacy
+%% `{Host, Port, Transport}' tuple aggregates over all TLS buckets of the
+%% triple; a `{Host, Port, Transport, TlsKey}' tuple counts one bucket.
 count(Name, Key) ->
     case find_pool(Name) of
         undefined -> 0;
@@ -455,6 +497,15 @@ handle_call(timeout, _From, #state{keepalive_timeout=Timeout}=State) ->
 handle_call(max_connections, _From, #state{max_connections=MaxConn}=State) ->
     {reply, MaxConn, State};
 
+handle_call({count, {Host, Port, Transport}}, _From, #state{available=Available}=State) ->
+    %% Legacy 3-tuple key: aggregate over all TLS buckets for the triple
+    Count = maps:fold(
+        fun({H, P, T, _K}, Pids, Acc) when H =:= Host, P =:= Port, T =:= Transport ->
+                Acc + length(Pids);
+           (_, _, Acc) -> Acc
+        end, 0, Available),
+    {reply, Count, State};
+
 handle_call({count, Key}, _From, #state{available=Available}=State) ->
     Count = case maps:find(Key, Available) of
                 {ok, Pids} -> length(Pids);
@@ -466,11 +517,11 @@ handle_call({host_stats, Host, Port}, _From, #state{available=Available, in_use=
     %% Count in_use and free for this host (any transport)
     HostLower = string:lowercase(Host),
     InUseCount = maps:fold(
-        fun(_Pid, {H, P, _T}, Acc) when H =:= HostLower, P =:= Port -> Acc + 1;
+        fun(_Pid, {H, P, _T, _K}, Acc) when H =:= HostLower, P =:= Port -> Acc + 1;
            (_, _, Acc) -> Acc
         end, 0, InUse),
     FreeCount = maps:fold(
-        fun({H, P, _T}, Pids, Acc) when H =:= HostLower, P =:= Port -> Acc + length(Pids);
+        fun({H, P, _T, _K}, Pids, Acc) when H =:= HostLower, P =:= Port -> Acc + length(Pids);
            (_, _, Acc) -> Acc
         end, 0, Available),
     {reply, {InUseCount, FreeCount}, State};
@@ -520,6 +571,32 @@ handle_call({checkout, Key, Requester, Opts}, _From, State) ->
                 {error, Reason} ->
                     {reply, {error, Reason}, State}
             end
+    end;
+
+handle_call({checkout_ssl, SslKey, Requester, Opts}, _From, State) ->
+    #state{name=PoolName, available=Available, in_use=InUse} = State,
+
+    ?report_trace("pool: checkout_ssl request", [{pool, PoolName}, {key, SslKey},
+        {total_in_use, maps:size(InUse)}]),
+
+    case find_available_ssl(SslKey, Available) of
+        {ok, Pid, Available2} ->
+            %% Found a pooled SSL connection with the same TLS options hash
+            ?report_debug("pool: reusing ssl connection", [{pool, PoolName}, {pid, Pid}]),
+            case hackney_conn:set_owner(Pid, Requester) of
+                ok ->
+                    InUse2 = maps:put(Pid, SslKey, InUse),
+                    {reply, {ok, Pid, ready},
+                     State#state{available=Available2, in_use=InUse2}};
+                {error, _} ->
+                    %% #850: the connection closed between is_ready and
+                    %% set_owner. It is already out of Available2; fall back
+                    %% to the TCP bucket with the dead conn dropped.
+                    checkout_ssl_fallback(SslKey, Requester, Opts,
+                                          State#state{available=Available2})
+            end;
+        none ->
+            checkout_ssl_fallback(SslKey, Requester, Opts, State)
     end;
 
 handle_call({checkin_sync, Pid}, _From, State) ->
@@ -681,7 +758,7 @@ handle_info({'DOWN', _MonRef, process, Pid, Reason}, State) ->
     InUse2 = case maps:take(Pid, InUse) of
         {Key, NewInUse} ->
             %% Connection died while in use - release the load_regulation slot
-            {Host, Port, _Transport} = Key,
+            {Host, Port} = key_host_port(Key),
             hackney_load_regulation:release(Host, Port),
             NewInUse;
         error ->
@@ -760,9 +837,19 @@ terminate(_Reason, #state{available=Available,
 %% Internal functions
 %%====================================================================
 
-connection_key(Host0, Port, Transport) ->
+%% @private Key for pooled connections. The 4th element buckets pooled SSL
+%% connections by the hash of their effective TLS options (ssl_pooling);
+%% plain TCP connections all use the `default' bucket.
+connection_key(Host, Port, Transport) ->
+    connection_key(Host, Port, Transport, default).
+
+connection_key(Host0, Port, Transport, TlsKey) ->
     Host = string:lowercase(Host0),
-    {Host, Port, Transport}.
+    {Host, Port, Transport, TlsKey}.
+
+%% @private Host and port of a pool connection key.
+key_host_port({Host, Port, _Transport, _TlsKey}) ->
+    {Host, Port}.
 
 %% @private Key for shared HTTP/2 connections. Includes the hash of the
 %% effective TLS options (tls_key) so requests with different ssl_options
@@ -787,6 +874,16 @@ stop_conn(Pid) ->
     try hackney_conn:stop(Pid) catch _:_ -> ok end.
 
 find_available(Key, Available) ->
+    find_available(Key, Available, true).
+
+%% @private Like find_available/2 but never redials a closed connection.
+%% Used for SSL buckets: hackney_conn:connect/1 on an upgraded conn would
+%% reconnect the raw transport without the upgrade handshake options, so a
+%% closed conn is stopped and dropped instead.
+find_available_ssl(Key, Available) ->
+    find_available(Key, Available, false).
+
+find_available(Key, Available, Redial) ->
     case maps:find(Key, Available) of
         {ok, [Pid | Rest]} ->
             Available2 = case Rest of
@@ -802,20 +899,23 @@ find_available(Key, Available) ->
                     %% noproc exit must not crash the pool, so skip and move on.
                     try hackney_conn:is_ready(Pid) of
                         {ok, connected} -> {ok, Pid, Available2};
-                        {ok, closed} ->
+                        {ok, closed} when Redial ->
                             %% Connection closed, try reconnect
                             try hackney_conn:connect(Pid) of
                                 ok -> {ok, Pid, Available2};
-                                _ -> find_available(Key, Available2)
+                                _ -> find_available(Key, Available2, Redial)
                             catch
-                                _:_ -> find_available(Key, Available2)
+                                _:_ -> find_available(Key, Available2, Redial)
                             end;
-                        _ -> find_available(Key, Available2)
+                        {ok, closed} ->
+                            stop_conn(Pid),
+                            find_available(Key, Available2, Redial);
+                        _ -> find_available(Key, Available2, Redial)
                     catch
-                        _:_ -> find_available(Key, Available2)
+                        _:_ -> find_available(Key, Available2, Redial)
                     end;
                 false ->
-                    find_available(Key, Available2)
+                    find_available(Key, Available2, Redial)
             end;
         {ok, []} ->
             none;
@@ -823,8 +923,56 @@ find_available(Key, Available) ->
             none
     end.
 
+%% @private SSL checkout miss: reuse or dial a TCP connection for the caller
+%% to upgrade. It is recorded in in_use under the SSL key so the checkin
+%% decision can tell it apart from plain TCP checkouts.
+checkout_ssl_fallback(SslKey, Requester, Opts, State) ->
+    #state{name=PoolName, max_connections=MaxConn,
+           available=Available, in_use=InUse} = State,
+    {Host, Port} = key_host_port(SslKey),
+    TcpKey = connection_key(Host, Port, hackney_tcp),
+    TotalInUse = maps:size(InUse),
+
+    case find_available(TcpKey, Available) of
+        {ok, Pid, Available2} ->
+            case hackney_conn:set_owner(Pid, Requester) of
+                ok ->
+                    InUse2 = maps:put(Pid, SslKey, InUse),
+                    {reply, {ok, Pid, needs_upgrade},
+                     State#state{available=Available2, in_use=InUse2}};
+                {error, _} ->
+                    %% #850 race again: drop the dead conn and dial fresh
+                    start_ssl_checkout_conn(SslKey, Requester, Opts,
+                                            State#state{available=Available2})
+            end;
+        none when TotalInUse >= MaxConn ->
+            ?report_trace("pool: at max connections", [{pool, PoolName}, {in_use, TotalInUse}]),
+            {reply, {error, checkout_timeout}, State};
+        none ->
+            ?report_trace("pool: starting new connection", [{pool, PoolName}]),
+            start_ssl_checkout_conn(SslKey, Requester, Opts, State)
+    end.
+
+%% @private Dial a fresh TCP connection for an SSL checkout. The caller
+%% upgrades it, so the dialed transport is TCP even though the in_use key
+%% carries hackney_ssl.
+start_ssl_checkout_conn(SslKey, Requester, Opts, State) ->
+    {Host, Port} = key_host_port(SslKey),
+    case start_connection(Host, Port, hackney_tcp, Requester, Opts, State) of
+        {ok, Pid, State2} ->
+            InUse2 = maps:put(Pid, SslKey, State2#state.in_use),
+            {reply, {ok, Pid, needs_upgrade}, State2#state{in_use=InUse2}};
+        {error, Reason} ->
+            {reply, {error, Reason}, State}
+    end.
+
 start_connection(Key, Owner, Opts, State) ->
-    {Host, Port, Transport} = Key,
+    %% Plain checkouts dial the key's transport; SSL-bucket checkouts dial
+    %% TCP explicitly via start_connection/6.
+    {Host, Port, Transport, _TlsKey} = Key,
+    start_connection(Host, Port, Transport, Owner, Opts, State).
+
+start_connection(Host, Port, Transport, Owner, Opts, State) ->
     ConnectTimeout = proplists:get_value(connect_timeout, Opts, 8000),
     RecvTimeout = proplists:get_value(recv_timeout, Opts, infinity),
     IdleTimeout = State#state.keepalive_timeout,
@@ -861,60 +1009,33 @@ start_connection(Key, Owner, Opts, State) ->
             {error, Reason}
     end.
 
-%% @private Process a checkin - return connection to pool
-%% Only TCP connections are stored. SSL upgraded connections are closed.
+%% @private Process a checkin - return connection to pool.
+%% Plain TCP connections are stored under their TCP key. An SSL upgraded
+%% connection is stored only when it was checked out through checkout_ssl
+%% (its in_use key carries hackney_ssl plus the TLS options hash) and still
+%% speaks HTTP/1.1; any other SSL conn is closed as before.
 %% Always releases the load_regulation slot since connection is no longer in use.
 do_checkin(Pid, State) ->
-    #state{in_use=InUse, available=Available, pid_monitors=PidMonitors} = State,
+    #state{in_use=InUse} = State,
 
     %% Get the key from in_use and remove
     case maps:take(Pid, InUse) of
         {Key, InUse2} ->
             %% Release load_regulation slot - connection is no longer in active use
-            {Host, Port, _Transport} = Key,
+            {Host, Port} = key_host_port(Key),
             hackney_load_regulation:release(Host, Port),
 
             %% Check if connection is still alive
             case is_process_alive(Pid) of
                 true ->
-                    %% Check if this connection should not be reused:
-                    %% - SSL upgraded connections (security requirement)
-                    %% - Proxy tunnel connections (SOCKS5, HTTP CONNECT - issue #283)
-                    ShouldClose = (try hackney_conn:is_upgraded_ssl(Pid) catch _:_ -> false end) =:= true orelse
-                                  (try hackney_conn:is_no_reuse(Pid) catch _:_ -> false end) =:= true,
-                    case ShouldClose of
+                    %% One call fetches every flag the decision needs
+                    Info = try hackney_conn:checkin_info(Pid) catch _:_ -> #{} end,
+                    case checkin_poolable(Key, Info) of
                         true ->
-                            %% Connection should not be reused - close it
+                            checkin_pool(Pid, Key, InUse2, State);
+                        false ->
                             stop_conn(Pid),
-                            %% Remove monitor if exists
-                            PidMonitors2 = case maps:take(Pid, PidMonitors) of
-                                {MonRef, PM} ->
-                                    erlang:demonitor(MonRef, [flush]),
-                                    PM;
-                                error -> PidMonitors
-                            end,
-                            State2 = State#state{in_use=InUse2, pid_monitors=PidMonitors2},
-                            %% Still trigger prewarm for TCP connections (for future SSL upgrades)
-                            TcpKey = {Host, Port, hackney_tcp},
-                            maybe_maintain_prewarm(TcpKey, activate_host(TcpKey, State2));
-                        _ ->
-                            %% Regular TCP connection - store in pool
-                            %% Set owner to pool so connection doesn't die if previous requester crashes.
-                            %% Use async version to avoid deadlock when called from checkin_sync
-                            hackney_conn:set_owner_async(Pid, self()),
-                            Available2 = maps:update_with(Key, fun(Pids) -> [Pid | Pids] end, [Pid], Available),
-
-                            %% Ensure we're monitoring this pid
-                            PidMonitors2 = case maps:is_key(Pid, PidMonitors) of
-                                true -> PidMonitors;
-                                false ->
-                                    MonRef = erlang:monitor(process, Pid),
-                                    maps:put(Pid, MonRef, PidMonitors)
-                            end,
-
-                            State2 = State#state{in_use=InUse2, available=Available2, pid_monitors=PidMonitors2},
-                            %% Maintain prewarm for activated hosts
-                            maybe_maintain_prewarm(Key, State2)
+                            checkin_close(Pid, Key, InUse2, State)
                     end;
                 false ->
                     State#state{in_use=InUse2}
@@ -923,17 +1044,76 @@ do_checkin(Pid, State) ->
             State
     end.
 
+%% @private Decide at checkin whether a conn can go back to the pool.
+%% The key shape records the checkout decision: an SSL-bucket key means the
+%% caller opted into ssl_pooling, so the conn is poolable only as an
+%% upgraded HTTPS/1.1 conn (HTTP/2 conns multiplex via h2_connections and
+%% must never enter `available'). A TCP key keeps the previous rule: never
+%% pool a conn that was SSL upgraded or marked no_reuse (proxy tunnels,
+%% issue #283). A failed checkin_info call defaults to the safe side of
+%% each rule: close for SSL keys, pool for TCP keys as before.
+checkin_poolable({_Host, _Port, hackney_ssl, _TlsKey}, Info) ->
+    maps:get(no_reuse, Info, true) =:= false andalso
+        maps:get(upgraded_ssl, Info, false) =:= true andalso
+        maps:get(protocol, Info, undefined) =:= http1;
+checkin_poolable(_TcpKey, Info) ->
+    maps:get(no_reuse, Info, false) =:= false andalso
+        maps:get(upgraded_ssl, Info, false) =:= false.
+
+%% @private Close branch of a checkin: drop the monitor and keep the host's
+%% TCP prewarm warm (the replacement for a closed conn is a TCP conn that
+%% gets upgraded on its next SSL checkout). The conn itself is stopped by
+%% the caller: stop_conn for async checkin, a stop cast for sync checkin
+%% where the conn is blocked waiting on the pool's reply.
+checkin_close(Pid, Key, InUse2, State) ->
+    #state{pid_monitors=PidMonitors} = State,
+    PidMonitors2 = case maps:take(Pid, PidMonitors) of
+        {MonRef, PM} ->
+            erlang:demonitor(MonRef, [flush]),
+            PM;
+        error -> PidMonitors
+    end,
+    State2 = State#state{in_use=InUse2, pid_monitors=PidMonitors2},
+    {Host, Port} = key_host_port(Key),
+    TcpKey = connection_key(Host, Port, hackney_tcp),
+    maybe_maintain_prewarm(TcpKey, activate_host(TcpKey, State2)).
+
+%% @private Pool branch of a checkin: hand ownership to the pool and store
+%% the conn under its checkout key (TCP or SSL bucket).
+%% set_owner is async so the sync checkin path never calls back into a conn
+%% that is blocked waiting on our reply.
+checkin_pool(Pid, Key, InUse2, State) ->
+    #state{available=Available, pid_monitors=PidMonitors} = State,
+    hackney_conn:set_owner_async(Pid, self()),
+    Available2 = maps:update_with(Key, fun(Pids) -> [Pid | Pids] end, [Pid], Available),
+
+    %% Ensure we're monitoring this pid
+    PidMonitors2 = case maps:is_key(Pid, PidMonitors) of
+        true -> PidMonitors;
+        false ->
+            MonRef = erlang:monitor(process, Pid),
+            maps:put(Pid, MonRef, PidMonitors)
+    end,
+
+    State2 = State#state{in_use=InUse2, available=Available2, pid_monitors=PidMonitors2},
+    %% Maintain prewarm for activated hosts. No-op for SSL keys: only TCP
+    %% keys are ever activated for prewarm.
+    maybe_maintain_prewarm(Key, State2).
+
 %% @private Process a checkin with known "should close" flag - avoids calling back to connection
 %% Used for sync checkin to prevent deadlock when connection calls pool.
-%% ShouldClose is true if connection was SSL upgraded or is a proxy tunnel (no_reuse).
+%% The conn computes the flag itself: true for proxy tunnels (no_reuse), SSL
+%% upgrades without ssl_pooling, and non HTTP/1.1 conns. A conn reaching the
+%% pool branch with an SSL key is therefore an upgraded HTTPS/1.1 conn that
+%% opted into ssl_pooling.
 do_checkin_with_close_flag(Pid, ShouldClose, State) ->
-    #state{in_use=InUse, available=Available, pid_monitors=PidMonitors} = State,
+    #state{in_use=InUse} = State,
 
     %% Get the key from in_use and remove
     case maps:take(Pid, InUse) of
         {Key, InUse2} ->
             %% Release load_regulation slot - connection is no longer in active use
-            {Host, Port, _Transport} = Key,
+            {Host, Port} = key_host_port(Key),
             hackney_load_regulation:release(Host, Port),
 
             %% Check if connection is still alive
@@ -945,34 +1125,9 @@ do_checkin_with_close_flag(Pid, ShouldClose, State) ->
                             %% Connection should not be reused - close it
                             %% Use cast to avoid deadlock (connection is waiting for our reply)
                             gen_statem:cast(Pid, stop),
-                            %% Remove monitor if exists
-                            PidMonitors2 = case maps:take(Pid, PidMonitors) of
-                                {MonRef, PM} ->
-                                    erlang:demonitor(MonRef, [flush]),
-                                    PM;
-                                error -> PidMonitors
-                            end,
-                            State2 = State#state{in_use=InUse2, pid_monitors=PidMonitors2},
-                            %% Still trigger prewarm for TCP connections (for future SSL upgrades)
-                            TcpKey = {Host, Port, hackney_tcp},
-                            maybe_maintain_prewarm(TcpKey, activate_host(TcpKey, State2));
+                            checkin_close(Pid, Key, InUse2, State);
                         _ ->
-                            %% Regular connection - store in pool
-                            %% Set owner to pool so connection doesn't die if previous requester crashes.
-                            hackney_conn:set_owner_async(Pid, self()),
-                            Available2 = maps:update_with(Key, fun(Pids) -> [Pid | Pids] end, [Pid], Available),
-
-                            %% Ensure we're monitoring this pid
-                            PidMonitors2 = case maps:is_key(Pid, PidMonitors) of
-                                true -> PidMonitors;
-                                false ->
-                                    MonRef = erlang:monitor(process, Pid),
-                                    maps:put(Pid, MonRef, PidMonitors)
-                            end,
-
-                            State2 = State#state{in_use=InUse2, available=Available2, pid_monitors=PidMonitors2},
-                            %% Maintain prewarm for activated hosts
-                            maybe_maintain_prewarm(Key, State2)
+                            checkin_pool(Pid, Key, InUse2, State)
                     end;
                 false ->
                     State#state{in_use=InUse2}
@@ -1088,7 +1243,7 @@ maybe_maintain_prewarm(Key, State) ->
             end,
             case CurrentCount < PrewarmCount of
                 true ->
-                    {Host, Port, _Transport} = Key,
+                    {Host, Port} = key_host_port(Key),
                     do_prewarm(Host, Port, PrewarmCount, State);
                 false ->
                     State
@@ -1118,7 +1273,8 @@ prewarm_connections(PoolPid, Host, Port, Count, IdleTimeout) ->
             case hackney_conn:connect(Pid) of
                 ok ->
                     %% Checkin the new connection to the pool
-                    gen_server:cast(PoolPid, {prewarm_checkin, Pid, {Host, Port, hackney_tcp}});
+                    gen_server:cast(PoolPid, {prewarm_checkin, Pid,
+                                              connection_key(Host, Port, hackney_tcp)});
                 {error, _Reason} ->
                     stop_conn(Pid)
             end;

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -152,7 +152,7 @@ checkout_h2(Host, Port, Transport, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     ConnectTimeout = proplists:get_value(connect_timeout, Options, 8000),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h2_connection_key(Host, Port, Transport, Options),
     try
         gen_server:call(Pool, {checkout_h2, Key}, ConnectTimeout)
     catch
@@ -167,7 +167,7 @@ checkout_h2(Host, Port, Transport, Options) ->
 register_h2(Host, Port, Transport, Pid, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h2_connection_key(Host, Port, Transport, Options),
     gen_server:cast(Pool, {register_h2, Key, Pid}),
     ok.
 
@@ -763,6 +763,14 @@ terminate(_Reason, #state{available=Available,
 connection_key(Host0, Port, Transport) ->
     Host = string:lowercase(Host0),
     {Host, Port, Transport}.
+
+%% @private Key for shared HTTP/2 connections. Includes the hash of the
+%% effective TLS options (tls_key) so requests with different ssl_options
+%% never share a connection. Callers that pass no tls_key all land in the
+%% `default' bucket, preserving the previous behavior.
+h2_connection_key(Host0, Port, Transport, Options) ->
+    Host = string:lowercase(Host0),
+    {Host, Port, Transport, proplists:get_value(tls_key, Options, default)}.
 
 %% @private Stop a connection, tolerating an already-dead process.
 stop_conn(Pid) ->

--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -199,7 +199,7 @@ checkout_h3(Host, Port, Transport, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     ConnectTimeout = proplists:get_value(connect_timeout, Options, 8000),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h3_connection_key(Host, Port, Transport, Options),
     try
         gen_server:call(Pool, {checkout_h3, Key}, ConnectTimeout)
     catch
@@ -214,7 +214,7 @@ checkout_h3(Host, Port, Transport, Options) ->
 register_h3(Host, Port, Transport, Pid, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h3_connection_key(Host, Port, Transport, Options),
     gen_server:cast(Pool, {register_h3, Key, Pid}),
     ok.
 
@@ -233,7 +233,7 @@ unregister_h3(Pid, Options) ->
 get_h3_session(Host, Port, Transport, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h3_connection_key(Host, Port, Transport, Options),
     try
         gen_server:call(Pool, {get_h3_session, Key})
     catch
@@ -247,7 +247,7 @@ get_h3_session(Host, Port, Transport, Options) ->
 store_h3_session(Host, Port, Transport, Ticket, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h3_connection_key(Host, Port, Transport, Options),
     gen_server:cast(Pool, {store_h3_session, Key, Ticket}),
     ok.
 
@@ -257,7 +257,7 @@ store_h3_session(Host, Port, Transport, Ticket, Options) ->
 delete_h3_session(Host, Port, Transport, Options) ->
     PoolName = proplists:get_value(pool, Options, default),
     Pool = find_pool(PoolName, Options),
-    Key = {Host, Port, Transport},
+    Key = h3_connection_key(Host, Port, Transport, Options),
     gen_server:cast(Pool, {delete_h3_session, Key}),
     ok.
 
@@ -771,6 +771,16 @@ connection_key(Host0, Port, Transport) ->
 h2_connection_key(Host0, Port, Transport, Options) ->
     Host = string:lowercase(Host0),
     {Host, Port, Transport, proplists:get_value(tls_key, Options, default)}.
+
+%% @private Key for shared HTTP/3 connections and cached 0-RTT session
+%% tickets. Includes the hash of the QUIC trust projection (h3_tls_key) so
+%% requests with differing trust configs never share a connection, and a
+%% ticket obtained under one trust config is never resumed under another.
+%% Callers that pass no h3_tls_key all land in the `default' bucket,
+%% preserving the previous behavior.
+h3_connection_key(Host0, Port, Transport, Options) ->
+    Host = string:lowercase(Host0),
+    {Host, Port, Transport, proplists:get_value(h3_tls_key, Options, default)}.
 
 %% @private Stop a connection, tolerating an already-dead process.
 stop_conn(Pid) ->

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -23,6 +23,8 @@
 -export([check_hostname_opts/1]).
 -export([cipher_opts/0]).
 -export([ssl_opts/2]).
+-export([effective_opts/3]).
+-export([options_key/1]).
 
 %% ALPN (Application-Layer Protocol Negotiation) for HTTP/2
 -export([alpn_opts/1]).
@@ -77,8 +79,36 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
       MergedOpts
   end.
 
+%% @doc Build the exact options handed to `ssl:connect/2' for an SSL upgrade.
+%% SslOpts is the caller's ssl_options, with an optional `{protocols, P}'
+%% entry prepended when the request carries one. ConnectOpts is only used
+%% as the ALPN fallback when SslOpts yields no ALPN protocols. Computing
+%% the final list once, caller-side, lets `options_key/1' hash the same
+%% term the handshake uses.
+-spec effective_opts(string(), list(), list()) -> list().
+effective_opts(Host, SslOpts, ConnectOpts) ->
+  SslOpts1 = [{server_name_indication, Host} | SslOpts],
+  Merged = ssl_opts(Host, [{ssl_options, SslOpts1}]),
+  Alpn = case alpn_opts(SslOpts1) of
+    [] -> alpn_opts(ConnectOpts);
+    AlpnOpts -> AlpnOpts
+  end,
+  Final0 = hackney_util:merge_opts(Merged, Alpn),
+  %% `protocols' is a hackney option, not an ssl one; keep it out of the
+  %% handshake options.
+  proplists:delete(protocols, Final0).
 
-
+%% @doc Hash the effective TLS options into a pool key component.
+%% 2-tuples are ukeysorted (first occurrence wins, preserving proplists
+%% lookup semantics) so option order does not change the key, while
+%% conflicting duplicates such as `[{verify,A},{verify,B}]' and its
+%% reverse still hash differently.
+-spec options_key(list()) -> binary().
+options_key(FinalSslOpts) ->
+  {Tuples, Rest} = lists:partition(
+    fun(T) -> is_tuple(T) andalso tuple_size(T) =:= 2 end,
+    FinalSslOpts),
+  crypto:hash(sha256, term_to_binary({lists:ukeysort(1, Tuples), lists:usort(Rest)})).
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -86,6 +86,16 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
 %% as the ALPN fallback when SslOpts yields no ALPN protocols. Computing
 %% the final list once, caller-side, lets `options_key/1' hash the same
 %% term the handshake uses.
+%%
+%% Requests on hackney's default TLS config (no user ssl_options) also get
+%% `{session_tickets, auto}' for TLS 1.3 session resumption, unless the
+%% `tls_session_resumption' application env is set to false or the node
+%% pins the ssl app to versions without 'tlsv1.3'. Custom ssl_options
+%% deliberately never get resumption: OTP's automatic ticket store is
+%% global per node and keyed by SNI, not by trust options, and a
+%% PSK-resumed handshake skips certificate validation. Restricting it to
+%% the default config means every participant in the store has identical
+%% trust, so trust configs cannot cross by construction.
 -spec effective_opts(string(), list(), list()) -> list().
 effective_opts(Host, SslOpts, ConnectOpts) ->
   SslOpts1 = [{server_name_indication, Host} | SslOpts],
@@ -97,7 +107,31 @@ effective_opts(Host, SslOpts, ConnectOpts) ->
   Final0 = hackney_util:merge_opts(Merged, Alpn),
   %% `protocols' is a hackney option, not an ssl one; keep it out of the
   %% handshake options.
-  proplists:delete(protocols, Final0).
+  Final = proplists:delete(protocols, Final0),
+  case resumption_allowed(SslOpts) of
+    true -> [{session_tickets, auto} | Final];
+    false -> Final
+  end.
+
+%% @private Resumption only for the default TLS config: the caller injects
+%% at most a `protocols' entry, so deleting it leaves [] exactly when the
+%% user passed no ssl_options (hence no insecure, versions or
+%% session_tickets overrides by construction).
+resumption_allowed(SslOpts) ->
+  proplists:delete(protocols, SslOpts) =:= []
+    andalso hackney_app:get_app_env(tls_session_resumption, true) =:= true
+    andalso tlsv13_allowed().
+
+%% @private OTP rejects `session_tickets' when 'tlsv1.3' is not among the
+%% effective versions (ssl_config asserts the version dependency), so honor
+%% a node-wide ssl `protocol_version' pin that excludes TLS 1.3.
+tlsv13_allowed() ->
+  case application:get_env(ssl, protocol_version) of
+    undefined -> true;
+    {ok, 'tlsv1.3'} -> true;
+    {ok, Versions} when is_list(Versions) -> lists:member('tlsv1.3', Versions);
+    {ok, _} -> false
+  end.
 
 %% @doc Hash the effective TLS options into a pool key component.
 %% 2-tuples are ukeysorted (first occurrence wins, preserving proplists

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -24,8 +24,13 @@
 -export([cipher_opts/0]).
 -export([ssl_opts/2]).
 -export([effective_opts/3]).
+-export([effective_opts_and_key/3]).
+-export([init_key_cache/0]).
 -export([options_key/1]).
 -export([h3_options_key/2]).
+
+-define(TLS_KEY_CACHE, hackney_tls_keys).
+-define(TLS_KEY_CACHE_MAX, 512).
 
 %% ALPN (Application-Layer Protocol Negotiation) for HTTP/2
 -export([alpn_opts/1]).
@@ -132,6 +137,60 @@ tlsv13_allowed() ->
     {ok, Versions} when is_list(Versions) -> lists:member('tlsv1.3', Versions);
     {ok, _} -> false
   end.
+
+%% @doc Create the TLS key memo table used by `effective_opts_and_key/3'.
+%% Idempotent; called from hackney_sup:init/1.
+-spec init_key_cache() -> ok.
+init_key_cache() ->
+  case ets:info(?TLS_KEY_CACHE) of
+    undefined ->
+      ?TLS_KEY_CACHE = ets:new(?TLS_KEY_CACHE,
+                               [set, public, named_table,
+                                {read_concurrency, true}]),
+      ok;
+    _ ->
+      ok
+  end.
+
+%% @doc Like `effective_opts/3' but also return `options_key/1' of the
+%% result, memoized in a bounded ETS cache. Building the options is cheap;
+%% hashing them is not (sha256 over the full term, dominated by the certifi
+%% CA bundle), so only the hash is cached. The memo key is the small
+%% pre-merge inputs plus `env_fingerprint/0', so a runtime env flip yields
+%% a fresh key instead of hashing connections into wrong pool buckets.
+-spec effective_opts_and_key(string(), list(), list()) -> {list(), binary()}.
+effective_opts_and_key(Host, SslOpts, ConnectOpts) ->
+  Final = effective_opts(Host, SslOpts, ConnectOpts),
+  MemoKey = {Host, SslOpts, ConnectOpts, env_fingerprint()},
+  try
+    case ets:lookup(?TLS_KEY_CACHE, MemoKey) of
+      [{_, Key}] ->
+        {Final, Key};
+      [] ->
+        Key = options_key(Final),
+        %% The bound is soft under concurrency; the cache is best-effort.
+        case ets:info(?TLS_KEY_CACHE, size) >= ?TLS_KEY_CACHE_MAX of
+          true -> _ = ets:delete_all_objects(?TLS_KEY_CACHE);
+          false -> ok
+        end,
+        _ = ets:insert(?TLS_KEY_CACHE, {MemoKey, Key}),
+        {Final, Key}
+    end
+  catch
+    %% Table absent: hackney used as a library without the app started.
+    error:badarg ->
+      {Final, options_key(Final)}
+  end.
+
+%% @private Invariant: this tuple must cover every mutable read inside
+%% effective_opts/3 (default_protocols via alpn_opts, the
+%% tls_session_resumption env via resumption_allowed, the ssl
+%% protocol_version env via tlsv13_allowed). Extend it whenever
+%% effective_opts/3 grows a new env read, or stale keys get served.
+env_fingerprint() ->
+  {hackney_util:default_protocols(),
+   hackney_app:get_app_env(tls_session_resumption, true),
+   application:get_env(ssl, protocol_version, undefined)}.
 
 %% @doc Hash the effective TLS options into a pool key component.
 %% 2-tuples are ukeysorted (first occurrence wins, preserving proplists

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -25,6 +25,7 @@
 -export([ssl_opts/2]).
 -export([effective_opts/3]).
 -export([options_key/1]).
+-export([h3_options_key/2]).
 
 %% ALPN (Application-Layer Protocol Negotiation) for HTTP/2
 -export([alpn_opts/1]).
@@ -109,6 +110,35 @@ options_key(FinalSslOpts) ->
     fun(T) -> is_tuple(T) andalso tuple_size(T) =:= 2 end,
     FinalSslOpts),
   crypto:hash(sha256, term_to_binary({lists:ukeysort(1, Tuples), lists:usort(Rest)})).
+
+%% @doc Hash the QUIC trust projection of an HTTP/3 connection into a pool
+%% key component. Includes exactly what decides server trust on the QUIC
+%% handshake, mirroring `hackney_conn:h3_tls_opts/2': the verify mode
+%% derived from the `insecure' flag (read from ConnectOpts first, then
+%% SslOpts) and the CA source from SslOpts (the `cacerts' list, else the
+%% `cacertfile' path, else the default trust store). The cacertfile path is
+%% hashed as given, without reading the file. Deliberately excluded:
+%% `session_ticket' (injected per resumption, so the conn-side store key
+%% must not depend on it), and `family' and `happy_eyeballs' (connectivity
+%% options that do not affect trust).
+-spec h3_options_key(list(), list()) -> binary().
+h3_options_key(ConnectOpts, SslOpts) ->
+  Insecure = proplists:get_value(insecure, ConnectOpts,
+               proplists:get_value(insecure, SslOpts, false)),
+  VerifyMode = case Insecure of
+    true -> verify_none;
+    false -> verify_peer
+  end,
+  CaSource = case proplists:get_value(cacerts, SslOpts) of
+    undefined ->
+      case proplists:get_value(cacertfile, SslOpts) of
+        undefined -> default;
+        File -> {cacertfile, File}
+      end;
+    CACerts ->
+      {cacerts, CACerts}
+  end,
+  crypto:hash(sha256, term_to_binary({VerifyMode, CaSource})).
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),

--- a/src/hackney_sup.erl
+++ b/src/hackney_sup.erl
@@ -42,6 +42,9 @@ init([]) ->
   %% initialize per-host load regulation
   hackney_load_regulation:init(),
 
+  %% initialize the TLS options key memo table
+  ok = hackney_ssl:init_key_cache(),
+
   Specs = [
            %% manager
            ?CHILD(hackney_manager, worker),

--- a/test/hackney_h3_zero_rtt_tests.erl
+++ b/test/hackney_h3_zero_rtt_tests.erl
@@ -108,7 +108,9 @@ pool_session_test_() ->
       {"get returns none when nothing cached", fun pool_get_none/0},
       {"store then get returns the ticket", fun pool_store_get/0},
       {"delete removes the cached ticket", fun pool_delete/0},
-      {"tickets are keyed by host/port/transport", fun pool_keying/0}
+      {"tickets are keyed by host/port/transport", fun pool_keying/0},
+      {"tickets are keyed by trust projection", fun pool_trust_keying/0},
+      {"explicit h3_tls_key round-trips store/get/delete", fun pool_tls_key_roundtrip/0}
      ]}.
 
 pool_get_none() ->
@@ -135,3 +137,30 @@ pool_keying() ->
     ok = hackney_pool:store_h3_session("c.example", 443, hackney_ssl, T, []),
     ?assertEqual(none,
                  hackney_pool:get_h3_session("c.example", 8443, hackney_ssl, [])).
+
+pool_trust_keying() ->
+    %% Regression for the trust hole: a ticket obtained under verify_none
+    %% must never be served to a verify_peer request, since 0-RTT PSK
+    %% resumption skips certificate validation.
+    T = {ticket, make_ref()},
+    InsecureKey = hackney_ssl:h3_options_key([{insecure, true}], []),
+    VerifyKey = hackney_ssl:h3_options_key([], []),
+    ok = hackney_pool:store_h3_session("d.example", 443, hackney_ssl, T,
+                                       [{h3_tls_key, InsecureKey}]),
+    ?assertEqual(none,
+                 hackney_pool:get_h3_session("d.example", 443, hackney_ssl,
+                                             [{h3_tls_key, VerifyKey}])),
+    ?assertEqual({ok, T},
+                 hackney_pool:get_h3_session("d.example", 443, hackney_ssl,
+                                             [{h3_tls_key, InsecureKey}])).
+
+pool_tls_key_roundtrip() ->
+    T = {ticket, make_ref()},
+    K = hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca.pem"}]),
+    Opts = [{h3_tls_key, K}],
+    ok = hackney_pool:store_h3_session("e.example", 443, hackney_ssl, T, Opts),
+    ?assertEqual({ok, T},
+                 hackney_pool:get_h3_session("e.example", 443, hackney_ssl, Opts)),
+    ok = hackney_pool:delete_h3_session("e.example", 443, hackney_ssl, Opts),
+    ?assertEqual(none,
+                 hackney_pool:get_h3_session("e.example", 443, hackney_ssl, Opts)).

--- a/test/hackney_pool_h3_tests.erl
+++ b/test/hackney_pool_h3_tests.erl
@@ -39,7 +39,9 @@ h3_pool_test_() ->
                 {"checkout_h3 returns none when no connection", fun test_h3_checkout_none/0},
                 {"register_h3 and checkout_h3", fun test_h3_register_checkout/0},
                 {"unregister_h3 removes connection", fun test_h3_unregister/0},
-                {"connection death cleans h3_connections", fun test_h3_connection_death/0}
+                {"connection death cleans h3_connections", fun test_h3_connection_death/0},
+                {"h3_tls_key isolates connections", fun test_h3_tls_key_isolation/0},
+                {"absent h3_tls_key uses default bucket", fun test_h3_tls_key_default_bucket/0}
             ]
         }
     }.
@@ -104,6 +106,41 @@ test_h3_connection_death() ->
 
     %% Checkout should detect the dead connection and return none
     ?assertEqual(none, hackney_pool:checkout_h3("h3death.example.com", 443, hackney_ssl, [])).
+
+test_h3_tls_key_isolation() ->
+    %% A connection registered under one trust key must not be handed out
+    %% for a request carrying a different trust key.
+    DummyConn = spawn(fun() -> receive stop -> ok end end),
+    K1 = hackney_ssl:h3_options_key([{insecure, true}], []),
+    K2 = hackney_ssl:h3_options_key([], []),
+    ok = hackney_pool:register_h3("h3key.example.com", 443, hackney_ssl, DummyConn,
+                                  [{h3_tls_key, K1}]),
+    timer:sleep(50),
+
+    ?assertEqual(none, hackney_pool:checkout_h3("h3key.example.com", 443, hackney_ssl,
+                                                [{h3_tls_key, K2}])),
+    ?assertEqual({ok, DummyConn},
+                 hackney_pool:checkout_h3("h3key.example.com", 443, hackney_ssl,
+                                          [{h3_tls_key, K1}])),
+
+    %% Cleanup
+    DummyConn ! stop.
+
+test_h3_tls_key_default_bucket() ->
+    %% Callers without an h3_tls_key land in the default bucket, isolated
+    %% from explicitly keyed connections.
+    DummyConn = spawn(fun() -> receive stop -> ok end end),
+    K1 = hackney_ssl:h3_options_key([{insecure, true}], []),
+    ok = hackney_pool:register_h3("h3default.example.com", 443, hackney_ssl, DummyConn, []),
+    timer:sleep(50),
+
+    ?assertEqual(none, hackney_pool:checkout_h3("h3default.example.com", 443, hackney_ssl,
+                                                [{h3_tls_key, K1}])),
+    ?assertEqual({ok, DummyConn},
+                 hackney_pool:checkout_h3("h3default.example.com", 443, hackney_ssl, [])),
+
+    %% Cleanup
+    DummyConn ! stop.
 
 %%====================================================================
 %% Multiplexing Tests

--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -13,6 +13,7 @@
 -include("hackney.hrl").
 
 -define(PORT, 8123).
+-define(SSL_PORT, 8129).
 
 %%====================================================================
 %% Test fixtures
@@ -59,7 +60,33 @@ hackney_pool_integration_test_() ->
       {"checkout timeout", {timeout, 120, fun test_checkout_timeout/0}},
       {"server close detected when idle (issue #544)", {timeout, 30, fun test_server_close_detected/0}},
       {"checkout survives a connection dying mid-liveness-check (PR #869)",
-       {timeout, 30, fun test_checkout_survives_dying_connection/0}}
+       {timeout, 30, fun test_checkout_survives_dying_connection/0}},
+      {"checkout_ssl without pooled conns returns needs_upgrade",
+       fun test_checkout_ssl_needs_upgrade/0},
+      {"checkin of an SSL-keyed conn that was never upgraded closes it",
+       fun test_checkout_ssl_unupgraded_closes/0},
+      {"checkin pools an upgraded HTTPS/1.1 conn under its SSL key",
+       fun test_checkin_ssl_pooled_stub/0},
+      {"checkin closes an SSL-keyed no_reuse conn",
+       fun test_checkin_ssl_no_reuse_stub/0},
+      {"checkin closes an SSL-keyed non-http1 conn",
+       fun test_checkin_ssl_wrong_protocol_stub/0},
+      {"count/2 aggregates legacy 3-tuples and host_stats spans buckets",
+       fun test_count_mixed_buckets/0}
+     ]}.
+
+%% HTTPS/1.1 ssl_pooling integration tests - require a TLS server
+hackney_pool_ssl_pooling_test_() ->
+    {setup,
+     fun setup_ssl/0,
+     fun teardown_ssl/1,
+     [
+      {"https conn is pooled and reused with ssl_pooling",
+       {timeout, 30, fun test_ssl_pooling_reuse/0}},
+      {"https conn closes at checkin without ssl_pooling",
+       {timeout, 30, fun test_ssl_pooling_default_off/0}},
+      {"different ssl_options never share a pooled conn",
+       {timeout, 30, fun test_ssl_pooling_isolation/0}}
      ]}.
 
 setup_unit() ->
@@ -88,6 +115,29 @@ teardown_integration(_) ->
     application:stop(hackney),
     error_logger:tty(true),
     ok.
+
+setup_ssl() ->
+    error_logger:tty(false),
+    {ok, _} = application:ensure_all_started(cowboy),
+    {ok, _} = application:ensure_all_started(hackney),
+    CertDir = cert_dir(),
+    Dispatch = cowboy_router:compile([{'_', [{"/[...]", test_http_resource, []}]}]),
+    {ok, _} = cowboy:start_tls(pool_ssl_test_server,
+                               [{port, ?SSL_PORT},
+                                {certfile, filename:join(CertDir, "server.pem")},
+                                {keyfile, filename:join(CertDir, "server.key")}],
+                               #{env => #{dispatch => Dispatch}}),
+    ok.
+
+teardown_ssl(_) ->
+    cowboy:stop_listener(pool_ssl_test_server),
+    application:stop(cowboy),
+    application:stop(hackney),
+    error_logger:tty(true),
+    ok.
+
+cert_dir() ->
+    filename:join([filename:dirname(code:which(?MODULE)), "..", "test", "certs"]).
 
 %%====================================================================
 %% Unit Tests
@@ -408,6 +458,220 @@ swap_field(F, _Old, _New) -> F.
 
 swap_one(Old, Old, New) -> New;
 swap_one(P, _Old, _New) -> P.
+
+%%====================================================================
+%% SSL Pooling Tests (checkout_ssl / checkin branching)
+%%====================================================================
+
+%% Stub conn that answers hackney_conn:checkin_info/1 with canned flags. It
+%% also ignores casts (set_owner_async, stop) and cooperates with
+%% gen_statem:stop/1 (system terminate) so the pool's close path never
+%% blocks on it.
+stub_conn(Info) ->
+    spawn(fun() -> stub_conn_loop(Info) end).
+
+stub_conn_loop(Info) ->
+    receive
+        {'$gen_call', From, checkin_info} ->
+            gen_statem:reply(From, Info),
+            stub_conn_loop(Info);
+        {system, From, {terminate, Reason}} ->
+            gen_statem:reply(From, ok),
+            exit(Reason);
+        {'$gen_cast', stop} ->
+            ok;
+        {'$gen_cast', _} ->
+            stub_conn_loop(Info);
+        stop ->
+            ok
+    end.
+
+%% Rename a pid key Old -> New in every pid-keyed map field of the pool
+%% state (in_use and pid_monitors), so a stub process can stand in for a
+%% checked out conn at checkin time.
+rename_pid_key(State, Old, New) ->
+    list_to_tuple([rename_key_field(F, Old, New) || F <- tuple_to_list(State)]).
+
+rename_key_field(M, Old, New) when is_map(M) ->
+    case maps:take(Old, M) of
+        {V, M2} -> maps:put(New, V, M2);
+        error -> M
+    end;
+rename_key_field(F, _Old, _New) -> F.
+
+%% Checkout an SSL-keyed conn and swap a stub in before checkin, so the
+%% checkin decision sees the stub's canned checkin_info flags.
+checkout_ssl_with_stub(PoolName, TlsKey, Info) ->
+    Pool = hackney_pool:find_pool(PoolName),
+    Opts = [{pool, PoolName}, {tls_key, TlsKey}],
+    {ok, PoolInfo, RealPid, needs_upgrade} =
+        hackney_pool:checkout_ssl("127.0.0.1", ?PORT, hackney_ssl, Opts),
+    Stub = stub_conn(Info),
+    _ = sys:replace_state(Pool, fun(S) -> rename_pid_key(S, RealPid, Stub) end),
+    {PoolInfo, RealPid, Stub}.
+
+test_checkout_ssl_needs_upgrade() ->
+    ok = hackney_pool:start_pool(test_pool_ssl_co, [{pool_size, 5}, {prewarm_count, 0}]),
+    TlsKey = crypto:hash(sha256, <<"ssl-co">>),
+    Opts = [{pool, test_pool_ssl_co}, {tls_key, TlsKey}],
+    Result = hackney_pool:checkout_ssl("127.0.0.1", ?PORT, hackney_ssl, Opts),
+    ?assertMatch({ok, {test_pool_ssl_co, {"127.0.0.1", ?PORT, hackney_ssl, TlsKey}, _, hackney_ssl},
+                  _, needs_upgrade}, Result),
+    {ok, _, Pid, needs_upgrade} = Result,
+    ?assert(is_process_alive(Pid)),
+    Stats = hackney_pool:get_stats(test_pool_ssl_co),
+    ?assertEqual(1, proplists:get_value(in_use_count, Stats)),
+    hackney_conn:stop(Pid),
+    ok = hackney_pool:stop_pool(test_pool_ssl_co).
+
+test_checkout_ssl_unupgraded_closes() ->
+    %% Anomaly guard: an SSL-keyed conn checked in without being upgraded
+    %% must be closed, never pooled.
+    ok = hackney_pool:start_pool(test_pool_ssl_anom, [{pool_size, 5}, {prewarm_count, 0}]),
+    TlsKey = crypto:hash(sha256, <<"ssl-anom">>),
+    Opts = [{pool, test_pool_ssl_anom}, {tls_key, TlsKey}],
+    {ok, PoolInfo, Pid, needs_upgrade} =
+        hackney_pool:checkout_ssl("127.0.0.1", ?PORT, hackney_ssl, Opts),
+    ok = hackney_pool:checkin(PoolInfo, Pid),
+    timer:sleep(50),
+    ?assertNot(is_process_alive(Pid)),
+    ?assertEqual(0, hackney_pool:count(test_pool_ssl_anom, {"127.0.0.1", ?PORT, hackney_ssl})),
+    ?assertEqual(0, proplists:get_value(free_count, hackney_pool:get_stats(test_pool_ssl_anom))),
+    ok = hackney_pool:stop_pool(test_pool_ssl_anom).
+
+test_checkin_ssl_pooled_stub() ->
+    ok = hackney_pool:start_pool(test_pool_ssl_ci1, [{pool_size, 5}, {prewarm_count, 0}]),
+    TlsKey = crypto:hash(sha256, <<"ssl-ci-1">>),
+    {PoolInfo, RealPid, Stub} = checkout_ssl_with_stub(test_pool_ssl_ci1, TlsKey,
+        #{upgraded_ssl => true, no_reuse => false, pool_ssl => true, protocol => http1}),
+    ok = hackney_pool:checkin(PoolInfo, Stub),
+    timer:sleep(50),
+    ?assert(is_process_alive(Stub)),
+    SslKey = {"127.0.0.1", ?PORT, hackney_ssl, TlsKey},
+    ?assertEqual(1, hackney_pool:count(test_pool_ssl_ci1, SslKey)),
+    ?assertEqual(1, hackney_pool:count(test_pool_ssl_ci1, {"127.0.0.1", ?PORT, hackney_ssl})),
+    ?assertEqual(1, proplists:get_value(free_count, hackney_pool:get_stats(test_pool_ssl_ci1))),
+    stop_dummy(Stub),
+    hackney_conn:stop(RealPid),
+    ok = hackney_pool:stop_pool(test_pool_ssl_ci1).
+
+test_checkin_ssl_no_reuse_stub() ->
+    ok = hackney_pool:start_pool(test_pool_ssl_ci2, [{pool_size, 5}, {prewarm_count, 0}]),
+    TlsKey = crypto:hash(sha256, <<"ssl-ci-2">>),
+    {PoolInfo, RealPid, Stub} = checkout_ssl_with_stub(test_pool_ssl_ci2, TlsKey,
+        #{upgraded_ssl => true, no_reuse => true, pool_ssl => true, protocol => http1}),
+    ok = hackney_pool:checkin(PoolInfo, Stub),
+    timer:sleep(50),
+    ?assertNot(is_process_alive(Stub)),
+    ?assertEqual(0, hackney_pool:count(test_pool_ssl_ci2, {"127.0.0.1", ?PORT, hackney_ssl})),
+    hackney_conn:stop(RealPid),
+    ok = hackney_pool:stop_pool(test_pool_ssl_ci2).
+
+test_checkin_ssl_wrong_protocol_stub() ->
+    %% An ALPN-negotiated h2 conn multiplexes via h2_connections and must
+    %% never enter the available map, even under an SSL key.
+    ok = hackney_pool:start_pool(test_pool_ssl_ci3, [{pool_size, 5}, {prewarm_count, 0}]),
+    TlsKey = crypto:hash(sha256, <<"ssl-ci-3">>),
+    {PoolInfo, RealPid, Stub} = checkout_ssl_with_stub(test_pool_ssl_ci3, TlsKey,
+        #{upgraded_ssl => true, no_reuse => false, pool_ssl => true, protocol => http2}),
+    ok = hackney_pool:checkin(PoolInfo, Stub),
+    timer:sleep(50),
+    ?assertNot(is_process_alive(Stub)),
+    ?assertEqual(0, hackney_pool:count(test_pool_ssl_ci3, {"127.0.0.1", ?PORT, hackney_ssl})),
+    hackney_conn:stop(RealPid),
+    ok = hackney_pool:stop_pool(test_pool_ssl_ci3).
+
+test_count_mixed_buckets() ->
+    ok = hackney_pool:start_pool(test_pool_mixed, [{pool_size, 10}, {prewarm_count, 0}]),
+    KeyA = crypto:hash(sha256, <<"bucket-a">>),
+    KeyB = crypto:hash(sha256, <<"bucket-b">>),
+    Poolable = #{upgraded_ssl => true, no_reuse => false, pool_ssl => true, protocol => http1},
+    %% Two SSL buckets with different TLS hashes
+    {PoolInfoA, RealA, StubA} = checkout_ssl_with_stub(test_pool_mixed, KeyA, Poolable),
+    {PoolInfoB, RealB, StubB} = checkout_ssl_with_stub(test_pool_mixed, KeyB, Poolable),
+    ok = hackney_pool:checkin(PoolInfoA, StubA),
+    ok = hackney_pool:checkin(PoolInfoB, StubB),
+    %% One plain TCP conn
+    TcpOpts = [{pool, test_pool_mixed}],
+    {ok, PoolInfoT, TcpPid} = hackney_pool:checkout("127.0.0.1", ?PORT, hackney_tcp, TcpOpts),
+    ok = hackney_pool:checkin(PoolInfoT, TcpPid),
+    timer:sleep(50),
+    %% Exact 4-tuple lookups see only their bucket
+    ?assertEqual(1, hackney_pool:count(test_pool_mixed, {"127.0.0.1", ?PORT, hackney_ssl, KeyA})),
+    ?assertEqual(1, hackney_pool:count(test_pool_mixed, {"127.0.0.1", ?PORT, hackney_ssl, KeyB})),
+    %% Legacy 3-tuples aggregate across buckets per transport
+    ?assertEqual(2, hackney_pool:count(test_pool_mixed, {"127.0.0.1", ?PORT, hackney_ssl})),
+    ?assertEqual(1, hackney_pool:count(test_pool_mixed, {"127.0.0.1", ?PORT, hackney_tcp})),
+    %% host_stats spans every bucket of the host
+    HostStats = hackney_pool:host_stats(test_pool_mixed, "127.0.0.1", ?PORT),
+    ?assertEqual(0, proplists:get_value(in_use, HostStats)),
+    ?assertEqual(3, proplists:get_value(free, HostStats)),
+    stop_dummy(StubA),
+    stop_dummy(StubB),
+    hackney_conn:stop(RealA),
+    hackney_conn:stop(RealB),
+    ok = hackney_pool:stop_pool(test_pool_mixed).
+
+%%====================================================================
+%% HTTPS/1.1 ssl_pooling Integration Tests
+%%====================================================================
+
+ssl_pool_url() ->
+    iolist_to_binary([<<"https://localhost:">>, integer_to_list(?SSL_PORT), <<"/get">>]).
+
+ssl_pool_opts(PoolName, ExtraSslOpts) ->
+    [{pool, PoolName},
+     {protocols, [http1]},
+     {ssl_options, [{insecure, true}, {verify, verify_none} | ExtraSslOpts]}].
+
+ssl_request(Opts) ->
+    {ok, 200, _, Body} = hackney:request(get, ssl_pool_url(), [], <<>>, Opts),
+    ?assert(is_binary(Body)),
+    ok.
+
+test_ssl_pooling_reuse() ->
+    ok = hackney_pool:start_pool(test_pool_ssl_reuse, [{pool_size, 5}, {prewarm_count, 0}]),
+    Opts = [{ssl_pooling, true} | ssl_pool_opts(test_pool_ssl_reuse, [])],
+    SslTriple = {"localhost", ?SSL_PORT, hackney_ssl},
+    ok = ssl_request(Opts),
+    timer:sleep(50),
+    %% The upgraded conn went back to the pool under its SSL key
+    ?assertEqual(1, hackney_pool:count(test_pool_ssl_reuse, SslTriple)),
+    ok = ssl_request(Opts),
+    timer:sleep(50),
+    %% Same TLS options: the pooled conn was reused, no second conn appeared
+    ?assertEqual(1, hackney_pool:count(test_pool_ssl_reuse, SslTriple)),
+    Stats = hackney_pool:get_stats(test_pool_ssl_reuse),
+    ?assertEqual(0, proplists:get_value(in_use_count, Stats)),
+    ?assertEqual(1, proplists:get_value(free_count, Stats)),
+    ok = hackney_pool:stop_pool(test_pool_ssl_reuse).
+
+test_ssl_pooling_default_off() ->
+    ok = hackney_pool:start_pool(test_pool_ssl_off, [{pool_size, 5}, {prewarm_count, 0}]),
+    Opts = ssl_pool_opts(test_pool_ssl_off, []),
+    ok = ssl_request(Opts),
+    timer:sleep(50),
+    %% Without ssl_pooling the upgraded conn is closed at checkin, as before
+    ?assertEqual(0, hackney_pool:count(test_pool_ssl_off, {"localhost", ?SSL_PORT, hackney_ssl})),
+    Stats = hackney_pool:get_stats(test_pool_ssl_off),
+    ?assertEqual(0, proplists:get_value(in_use_count, Stats)),
+    ?assertEqual(0, proplists:get_value(free_count, Stats)),
+    ok = hackney_pool:stop_pool(test_pool_ssl_off).
+
+test_ssl_pooling_isolation() ->
+    ok = hackney_pool:start_pool(test_pool_ssl_iso, [{pool_size, 5}, {prewarm_count, 0}]),
+    OptsX = [{ssl_pooling, true} | ssl_pool_opts(test_pool_ssl_iso, [])],
+    OptsY = [{ssl_pooling, true} | ssl_pool_opts(test_pool_ssl_iso, [{depth, 3}])],
+    SslTriple = {"localhost", ?SSL_PORT, hackney_ssl},
+    ok = ssl_request(OptsX),
+    timer:sleep(50),
+    ?assertEqual(1, hackney_pool:count(test_pool_ssl_iso, SslTriple)),
+    %% Different ssl_options hash to a different bucket: the pooled conn is
+    %% not reused and a second conn shows up
+    ok = ssl_request(OptsY),
+    timer:sleep(50),
+    ?assertEqual(2, hackney_pool:count(test_pool_ssl_iso, SslTriple)),
+    ok = hackney_pool:stop_pool(test_pool_ssl_iso).
 
 %%====================================================================
 %% Prewarm Tests

--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -31,6 +31,17 @@ hackney_pool_unit_test_() ->
       {"timeout setting", fun test_timeout_setting/0}
      ]}.
 
+%% HTTP/2 tls_key bucket tests - no server required
+hackney_pool_h2_tls_key_test_() ->
+    {setup,
+     fun setup_unit/0,
+     fun teardown_unit/1,
+     [
+      {"h2 checkout with a different tls_key returns none", fun test_h2_tls_key_mismatch/0},
+      {"h2 checkout with the matching tls_key returns the conn", fun test_h2_tls_key_match/0},
+      {"h2 default bucket is isolated from keyed bucket", fun test_h2_tls_key_default_bucket/0}
+     ]}.
+
 %% Integration tests - require server
 hackney_pool_integration_test_() ->
     {setup,
@@ -127,6 +138,69 @@ test_timeout_setting() ->
     timer:sleep(10),
     ?assertEqual(2000, hackney_pool:timeout(test_pool_5)),  % Capped at 2s
     ok = hackney_pool:stop_pool(test_pool_5).
+
+%%====================================================================
+%% HTTP/2 tls_key Bucket Tests
+%%====================================================================
+
+%% Dummy connection that answers hackney_conn:get_state/1 (used by the
+%% pool's h2_conn_usable liveness check) with {ok, connected}.
+dummy_h2_conn() ->
+    spawn(fun dummy_h2_loop/0).
+
+dummy_h2_loop() ->
+    receive
+        {'$gen_call', From, get_state} ->
+            gen_statem:reply(From, {ok, connected}),
+            dummy_h2_loop();
+        stop ->
+            ok
+    end.
+
+stop_dummy(Conn) ->
+    Conn ! stop,
+    timer:sleep(50).
+
+test_h2_tls_key_mismatch() ->
+    ok = hackney_pool:start_pool(test_pool_h2_key_1, []),
+    Conn = dummy_h2_conn(),
+    Opts1 = [{pool, test_pool_h2_key_1}, {tls_key, crypto:hash(sha256, <<"opts-one">>)}],
+    Opts2 = [{pool, test_pool_h2_key_1}, {tls_key, crypto:hash(sha256, <<"opts-two">>)}],
+    ok = hackney_pool:register_h2("h2key.example.com", 443, hackney_ssl, Conn, Opts1),
+    timer:sleep(50),
+    %% A request carrying different TLS options must not get this conn
+    ?assertEqual(none, hackney_pool:checkout_h2("h2key.example.com", 443, hackney_ssl, Opts2)),
+    stop_dummy(Conn),
+    ok = hackney_pool:stop_pool(test_pool_h2_key_1).
+
+test_h2_tls_key_match() ->
+    ok = hackney_pool:start_pool(test_pool_h2_key_2, []),
+    Conn = dummy_h2_conn(),
+    Opts = [{pool, test_pool_h2_key_2}, {tls_key, crypto:hash(sha256, <<"opts-one">>)}],
+    ok = hackney_pool:register_h2("h2key.example.com", 443, hackney_ssl, Conn, Opts),
+    timer:sleep(50),
+    ?assertEqual({ok, Conn}, hackney_pool:checkout_h2("h2key.example.com", 443, hackney_ssl, Opts)),
+    stop_dummy(Conn),
+    ok = hackney_pool:stop_pool(test_pool_h2_key_2).
+
+test_h2_tls_key_default_bucket() ->
+    %% Callers that pass no tls_key land in the default bucket, isolated
+    %% from keyed registrations.
+    ok = hackney_pool:start_pool(test_pool_h2_key_3, []),
+    KeyedConn = dummy_h2_conn(),
+    DefaultConn = dummy_h2_conn(),
+    KeyedOpts = [{pool, test_pool_h2_key_3}, {tls_key, crypto:hash(sha256, <<"opts-one">>)}],
+    DefaultOpts = [{pool, test_pool_h2_key_3}],
+    ok = hackney_pool:register_h2("h2def.example.com", 443, hackney_ssl, KeyedConn, KeyedOpts),
+    ok = hackney_pool:register_h2("h2def.example.com", 443, hackney_ssl, DefaultConn, DefaultOpts),
+    timer:sleep(50),
+    ?assertEqual({ok, DefaultConn},
+                 hackney_pool:checkout_h2("h2def.example.com", 443, hackney_ssl, DefaultOpts)),
+    ?assertEqual({ok, KeyedConn},
+                 hackney_pool:checkout_h2("h2def.example.com", 443, hackney_ssl, KeyedOpts)),
+    stop_dummy(KeyedConn),
+    stop_dummy(DefaultConn),
+    ok = hackney_pool:stop_pool(test_pool_h2_key_3).
 
 %%====================================================================
 %% Connection Tests

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -100,3 +100,69 @@ partial_chain_preserved_test() ->
     Opts = hackney_ssl:check_hostname_opts("example.com"),
     PartialChain = proplists:get_value(partial_chain, Opts),
     ?assert(is_function(PartialChain, 1)).
+
+%%====================================================================
+%% effective_opts / options_key Tests (Unit tests)
+%%====================================================================
+
+effective_opts_default_test() ->
+    Opts = hackney_ssl:effective_opts("example.com", [], []),
+    ?assertEqual("example.com", proplists:get_value(server_name_indication, Opts)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, Opts)),
+    ?assert(lists:keymember(cacerts, 1, Opts) orelse lists:keymember(cacertfile, 1, Opts)).
+
+effective_opts_no_protocols_leak_test() ->
+    %% The hackney-level protocols option must not reach ssl:connect,
+    %% but it must still drive the advertised ALPN protocols.
+    Opts = hackney_ssl:effective_opts("example.com", [{protocols, [http2, http1]}], []),
+    ?assertNot(proplists:is_defined(protocols, Opts)),
+    ?assertEqual([<<"h2">>, <<"http/1.1">>],
+                 proplists:get_value(alpn_advertised_protocols, Opts)).
+
+options_key_deterministic_across_processes_test() ->
+    Parent = self(),
+    Compute = fun() ->
+        Key = hackney_ssl:options_key(
+                hackney_ssl:effective_opts("example.com", [], [])),
+        Parent ! {key, self(), Key}
+    end,
+    Pid1 = spawn(Compute),
+    Pid2 = spawn(Compute),
+    Key1 = receive {key, Pid1, K1} -> K1 after 5000 -> error(timeout) end,
+    Key2 = receive {key, Pid2, K2} -> K2 after 5000 -> error(timeout) end,
+    ?assertEqual(Key1, Key2),
+    ?assertEqual(Key1, hackney_ssl:options_key(
+                         hackney_ssl:effective_opts("example.com", [], []))).
+
+options_key_differs_per_host_test() ->
+    KeyA = hackney_ssl:options_key(hackney_ssl:effective_opts("a.example.com", [], [])),
+    KeyB = hackney_ssl:options_key(hackney_ssl:effective_opts("b.example.com", [], [])),
+    ?assertNotEqual(KeyA, KeyB).
+
+options_key_differs_on_verify_test() ->
+    Default = hackney_ssl:options_key(
+                hackney_ssl:effective_opts("example.com", [], [])),
+    NoVerify = hackney_ssl:options_key(
+                 hackney_ssl:effective_opts("example.com", [{verify, verify_none}], [])),
+    ?assertNotEqual(Default, NoVerify).
+
+options_key_differs_on_alpn_test() ->
+    Default = hackney_ssl:options_key(
+                hackney_ssl:effective_opts("example.com", [], [])),
+    Http1Only = hackney_ssl:options_key(
+                  hackney_ssl:effective_opts("example.com", [{protocols, [http1]}], [])),
+    ?assertNotEqual(Default, Http1Only).
+
+options_key_duplicate_order_test() ->
+    %% ukeysort keeps the first occurrence (proplists semantics), so
+    %% conflicting duplicates must hash differently depending on order.
+    Base = [{server_name_indication, "example.com"}],
+    Key1 = hackney_ssl:options_key([{verify, verify_none}, {verify, verify_peer} | Base]),
+    Key2 = hackney_ssl:options_key([{verify, verify_peer}, {verify, verify_none} | Base]),
+    ?assertNotEqual(Key1, Key2).
+
+options_key_order_insensitive_test() ->
+    %% Reordering distinct options must not change the key.
+    Opts1 = [{verify, verify_none}, {server_name_indication, "example.com"}],
+    Opts2 = [{server_name_indication, "example.com"}, {verify, verify_none}],
+    ?assertEqual(hackney_ssl:options_key(Opts1), hackney_ssl:options_key(Opts2)).

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -218,3 +218,148 @@ h3_options_key_deterministic_across_processes_test() ->
     Key2 = receive {h3_key, Pid2, K2} -> K2 after 5000 -> error(timeout) end,
     ?assertEqual(Key1, Key2),
     ?assertEqual(Key1, hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca-a.pem"}])).
+
+%%====================================================================
+%% TLS 1.3 session resumption Tests (Unit tests)
+%%====================================================================
+
+effective_opts_resumption_default_test() ->
+    Opts = hackney_ssl:effective_opts("example.com", [], []),
+    ?assertEqual(auto, proplists:get_value(session_tickets, Opts)).
+
+effective_opts_resumption_with_protocols_test() ->
+    %% A caller-injected protocols entry is still the default TLS config.
+    Opts = hackney_ssl:effective_opts("example.com", [{protocols, [http2, http1]}], []),
+    ?assertEqual(auto, proplists:get_value(session_tickets, Opts)).
+
+effective_opts_no_resumption_with_custom_ssl_opts_test() ->
+    %% Any user-supplied ssl_options must opt the request out of the
+    %% node-global ticket store (trust isolation).
+    lists:foreach(
+      fun(SslOpts) ->
+          Opts = hackney_ssl:effective_opts("example.com", SslOpts, []),
+          ?assertNot(proplists:is_defined(session_tickets, Opts))
+      end,
+      [[{verify, verify_none}],
+       [{versions, ['tlsv1.2']}],
+       [{insecure, true}]]).
+
+effective_opts_resumption_kill_switch_test() ->
+    application:set_env(hackney, tls_session_resumption, false),
+    try
+        Opts = hackney_ssl:effective_opts("example.com", [], []),
+        ?assertNot(proplists:is_defined(session_tickets, Opts))
+    after
+        application:unset_env(hackney, tls_session_resumption)
+    end.
+
+effective_opts_resumption_requires_tlsv13_test() ->
+    %% OTP rejects session_tickets when 'tlsv1.3' is not among the
+    %% versions, so a node-wide ssl protocol_version pin must disable it.
+    application:set_env(ssl, protocol_version, ['tlsv1.2']),
+    try
+        Opts = hackney_ssl:effective_opts("example.com", [], []),
+        ?assertNot(proplists:is_defined(session_tickets, Opts))
+    after
+        application:unset_env(ssl, protocol_version)
+    end.
+
+options_key_differs_on_resumption_test() ->
+    %% Resumption-enabled and resumption-disabled connections are
+    %% handshaken differently and must not share pool buckets.
+    On = hackney_ssl:options_key(hackney_ssl:effective_opts("example.com", [], [])),
+    application:set_env(hackney, tls_session_resumption, false),
+    Off = try
+        hackney_ssl:options_key(hackney_ssl:effective_opts("example.com", [], []))
+    after
+        application:unset_env(hackney, tls_session_resumption)
+    end,
+    ?assertNotEqual(On, Off).
+
+%%====================================================================
+%% TLS 1.3 session resumption (integration, local TLS listener)
+%%====================================================================
+
+%% Resolve test cert dir from the module's beam location so the paths work
+%% regardless of where eunit is run from.
+cert_dir() ->
+    BeamDir = filename:dirname(code:which(?MODULE)),
+    %% _build/test/lib/hackney/test -> project root -> test/certs
+    Root = filename:join([BeamDir, "..", "..", "..", "..", ".."]),
+    filename:join([filename:absname(Root), "test", "certs"]).
+
+tls13_session_resumption_integration_test_() ->
+    {timeout, 15, fun run_tls13_session_resumption/0}.
+
+run_tls13_session_resumption() ->
+    {ok, _} = application:ensure_all_started(ssl),
+    Certs = cert_dir(),
+    {ok, ListenSock} = ssl:listen(0,
+        [binary, {active, false}, {reuseaddr, true},
+         {certfile, filename:join(Certs, "server.pem")},
+         {keyfile, filename:join(Certs, "server.key")},
+         {versions, ['tlsv1.3', 'tlsv1.2']},
+         {session_tickets, stateless}]),
+    {ok, {_, Port}} = ssl:sockname(ListenSock),
+    Acceptor = spawn_link(fun() -> tls13_accept_loop(ListenSock) end),
+    try
+        S1 = tls13_connect(Port),
+        %% NewSessionTicket messages arrive asynchronously after the
+        %% handshake; give the client ticket store a moment to record one.
+        timer:sleep(300),
+        ok = ssl:close(S1),
+        ?assert(tls13_resumed(Port, 10))
+    after
+        unlink(Acceptor),
+        exit(Acceptor, kill),
+        ssl:close(ListenSock)
+    end.
+
+%% Upgrade-style connect, like hackney does: raw TCP first, then
+%% ssl:connect/3 on the socket. verify_none avoids certifi validation of
+%% the localhost test cert.
+tls13_connect(Port) ->
+    {ok, Sock} = gen_tcp:connect("127.0.0.1", Port,
+                                 [binary, {active, false}], 2000),
+    {ok, SslSock} = ssl:connect(Sock,
+                                [{verify, verify_none},
+                                 {session_tickets, auto},
+                                 {versions, ['tlsv1.3']}], 2000),
+    SslSock.
+
+tls13_resumed(_Port, 0) ->
+    false;
+tls13_resumed(Port, Retries) ->
+    S = tls13_connect(Port),
+    Info = ssl:connection_information(S, [session_resumption]),
+    ok = ssl:close(S),
+    case Info of
+        {ok, [{session_resumption, true}]} ->
+            true;
+        _ ->
+            timer:sleep(200),
+            tls13_resumed(Port, Retries - 1)
+    end.
+
+tls13_accept_loop(ListenSock) ->
+    case ssl:transport_accept(ListenSock, 10000) of
+        {ok, TSock} ->
+            Pid = spawn_link(fun() ->
+                receive
+                    {go, Sock} ->
+                        case ssl:handshake(Sock, 5000) of
+                            {ok, SslSock} ->
+                                %% Hold the connection until the client
+                                %% closes it.
+                                _ = ssl:recv(SslSock, 0, 10000);
+                            _ ->
+                                ok
+                        end
+                end
+            end),
+            ok = ssl:controlling_process(TSock, Pid),
+            Pid ! {go, TSock},
+            tls13_accept_loop(ListenSock);
+        {error, _} ->
+            ok
+    end.

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -166,3 +166,55 @@ options_key_order_insensitive_test() ->
     Opts1 = [{verify, verify_none}, {server_name_indication, "example.com"}],
     Opts2 = [{server_name_indication, "example.com"}, {verify, verify_none}],
     ?assertEqual(hackney_ssl:options_key(Opts1), hackney_ssl:options_key(Opts2)).
+
+%%====================================================================
+%% h3_options_key Tests (Unit tests)
+%%====================================================================
+
+h3_options_key_insecure_differs_test() ->
+    Default = hackney_ssl:h3_options_key([], []),
+    InsecureConnect = hackney_ssl:h3_options_key([{insecure, true}], []),
+    InsecureSsl = hackney_ssl:h3_options_key([], [{insecure, true}]),
+    ?assertNotEqual(Default, InsecureConnect),
+    ?assertNotEqual(Default, InsecureSsl),
+    %% Same trust projection regardless of which list carries the flag.
+    ?assertEqual(InsecureConnect, InsecureSsl).
+
+h3_options_key_cacertfile_test() ->
+    Default = hackney_ssl:h3_options_key([], []),
+    FileA = hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca-a.pem"}]),
+    FileB = hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca-b.pem"}]),
+    ?assertNotEqual(Default, FileA),
+    ?assertNotEqual(FileA, FileB).
+
+h3_options_key_cacerts_test() ->
+    Default = hackney_ssl:h3_options_key([], []),
+    CertsA = hackney_ssl:h3_options_key([], [{cacerts, [<<"der-a">>]}]),
+    CertsB = hackney_ssl:h3_options_key([], [{cacerts, [<<"der-b">>]}]),
+    ?assertNotEqual(Default, CertsA),
+    ?assertNotEqual(CertsA, CertsB).
+
+h3_options_key_ignores_non_trust_opts_test() ->
+    %% session_ticket is injected per resumption and family/happy_eyeballs
+    %% are connectivity options; none of them affect trust, so none of them
+    %% may change the key.
+    Default = hackney_ssl:h3_options_key([], []),
+    ?assertEqual(Default, hackney_ssl:h3_options_key([{session_ticket, foo}], [])),
+    ?assertEqual(Default, hackney_ssl:h3_options_key([], [{session_ticket, foo}])),
+    ?assertEqual(Default, hackney_ssl:h3_options_key([{family, inet6}], [])),
+    ?assertEqual(Default, hackney_ssl:h3_options_key([], [{family, inet6}])),
+    ?assertEqual(Default, hackney_ssl:h3_options_key([{happy_eyeballs, false}], [])),
+    ?assertEqual(Default, hackney_ssl:h3_options_key([], [{happy_eyeballs, false}])).
+
+h3_options_key_deterministic_across_processes_test() ->
+    Parent = self(),
+    Compute = fun() ->
+        Key = hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca-a.pem"}]),
+        Parent ! {h3_key, self(), Key}
+    end,
+    Pid1 = spawn(Compute),
+    Pid2 = spawn(Compute),
+    Key1 = receive {h3_key, Pid1, K1} -> K1 after 5000 -> error(timeout) end,
+    Key2 = receive {h3_key, Pid2, K2} -> K2 after 5000 -> error(timeout) end,
+    ?assertEqual(Key1, Key2),
+    ?assertEqual(Key1, hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca-a.pem"}])).

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -277,6 +277,83 @@ options_key_differs_on_resumption_test() ->
     ?assertNotEqual(On, Off).
 
 %%====================================================================
+%% effective_opts_and_key memoization Tests (Unit tests)
+%%====================================================================
+
+%% The absent-table test deletes and recreates the cache, so it must run
+%% last; the funs in this fixture run in order.
+tls_key_cache_test_() ->
+    {setup,
+     fun() -> ok = hackney_ssl:init_key_cache() end,
+     fun(_) -> ok end,
+     [fun tls_key_cache_matches_unmemoized/0,
+      fun tls_key_cache_hit_path/0,
+      fun tls_key_cache_distinct_inputs/0,
+      fun tls_key_cache_env_fingerprint/0,
+      fun tls_key_cache_cap_flush/0,
+      fun tls_key_cache_absent_table/0]}.
+
+tls_key_cache_matches_unmemoized() ->
+    true = ets:delete_all_objects(hackney_tls_keys),
+    {F, K} = hackney_ssl:effective_opts_and_key("example.com", [], []),
+    ?assertEqual(hackney_ssl:effective_opts("example.com", [], []), F),
+    ?assertEqual(hackney_ssl:options_key(F), K).
+
+tls_key_cache_hit_path() ->
+    true = ets:delete_all_objects(hackney_tls_keys),
+    {_, K1} = hackney_ssl:effective_opts_and_key("example.com", [], []),
+    ?assertEqual(1, ets:info(hackney_tls_keys, size)),
+    {_, K2} = hackney_ssl:effective_opts_and_key("example.com", [], []),
+    ?assertEqual(K1, K2),
+    ?assertEqual(1, ets:info(hackney_tls_keys, size)).
+
+tls_key_cache_distinct_inputs() ->
+    true = ets:delete_all_objects(hackney_tls_keys),
+    {_, KA} = hackney_ssl:effective_opts_and_key("a.example.com", [], []),
+    {_, KB} = hackney_ssl:effective_opts_and_key("b.example.com", [], []),
+    {_, KC} = hackney_ssl:effective_opts_and_key(
+                "a.example.com", [{verify, verify_none}], []),
+    ?assertNotEqual(KA, KB),
+    ?assertNotEqual(KA, KC),
+    ?assertEqual(3, ets:info(hackney_tls_keys, size)).
+
+tls_key_cache_env_fingerprint() ->
+    %% A runtime env flip changes the effective options, so the memo must
+    %% not serve the key cached under the previous env.
+    true = ets:delete_all_objects(hackney_tls_keys),
+    {_, On} = hackney_ssl:effective_opts_and_key("example.com", [], []),
+    application:set_env(hackney, tls_session_resumption, false),
+    Off = try
+        {_, K} = hackney_ssl:effective_opts_and_key("example.com", [], []),
+        K
+    after
+        application:unset_env(hackney, tls_session_resumption)
+    end,
+    ?assertNotEqual(On, Off).
+
+tls_key_cache_cap_flush() ->
+    true = ets:delete_all_objects(hackney_tls_keys),
+    lists:foreach(
+      fun(I) ->
+          Host = "host-" ++ integer_to_list(I) ++ ".example.com",
+          {_, _} = hackney_ssl:effective_opts_and_key(Host, [], [])
+      end,
+      lists:seq(1, 600)),
+    ?assert(ets:info(hackney_tls_keys, size) =< 512).
+
+tls_key_cache_absent_table() ->
+    %% Without the app started the table does not exist; the function must
+    %% still return correct results.
+    true = ets:delete(hackney_tls_keys),
+    try
+        {F, K} = hackney_ssl:effective_opts_and_key("example.com", [], []),
+        ?assertEqual(hackney_ssl:effective_opts("example.com", [], []), F),
+        ?assertEqual(hackney_ssl:options_key(F), K)
+    after
+        ok = hackney_ssl:init_key_cache()
+    end.
+
+%%====================================================================
 %% TLS 1.3 session resumption (integration, local TLS listener)
 %%====================================================================
 


### PR DESCRIPTION
Connections carrying TLS state are now keyed by the ssl options they were established with. Shared HTTP/2 and HTTP/3 connections and cached 0-RTT session tickets get this unconditionally: requests with different ssl_options no longer share a multiplexed connection, and a session ticket obtained with verify_none can no longer be resumed by a verify_peer request.

On top of that, {ssl_pooling, true} (request option or application env, default false) extends pooling to HTTPS/1.1: an upgraded SSL connection returns to the pool keyed by a hash of its effective TLS options and is reused only on an exact match, skipping the per-request TLS handshake. Without the option SSL connections are closed at checkin as before.

Two more commits round this out: requests on the default TLS config get TLS 1.3 session resumption ({session_tickets, auto}, opt-out via the tls_session_resumption env; custom ssl_options never participate since OTP's ticket store is global and resumption skips certificate validation), and the TLS options hash is memoized in a bounded ETS cache (~80us down to ~1us per request). Fixes #872.