### PR TITLE
Improve client-side SNI, bump quic 1.6.5 and webtransport 0.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,13 @@ unreleased
 - The TLS options hash computed for every pooled HTTPS request is memoized in
   a bounded ETS cache keyed by the pre-merge inputs and the relevant
   application envs, skipping a sha256 over the full CA bundle on cache hits.
+- SNI handling. No `server_name_indication` is sent when the host is an IP
+  literal (RFC 6066), on HTTP/1.1, HTTP/2 and HTTP/3. A user-supplied
+  `server_name_indication` in `ssl_options` is now honored consistently as
+  both the wire value and the hostname-verification target, works on the
+  HTTP/3 path too, and `disable` suppresses SNI without weakening
+  verification.
+- Bump `quic` to 1.6.5 and `webtransport` to 0.4.0.
 
 4.2.3 - 2026-06-10
 ------------------

--- a/rebar.config
+++ b/rebar.config
@@ -53,11 +53,11 @@
 
 {deps, [
         %% Pure Erlang QUIC + HTTP/3 stack
-        {quic, "1.6.4"},
+        {quic, "1.6.5"},
         %% Pure Erlang HTTP/2 stack
         {h2, "0.9.0"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
-        {webtransport, "0.3.3"},
+        {webtransport, "0.4.0"},
         {idna, "~>7.1.0"},
         {mimerl, "~>1.4"},
         {certifi, "~>2.17.0"},

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -2463,24 +2463,15 @@ do_tcp_connect(From, Data) ->
     TransportOpts = proplists:delete(protocols, ConnectOpts),
     Opts = case Transport of
         hackney_ssl ->
-            FinalSslOpts = case SslOpts0 of
-                [] ->
-                    %% Default TLS config: build the handshake options like the
-                    %% pooled path does, which also makes the connection
-                    %% eligible for TLS 1.3 session resumption.
-                    SslOpts1 = case proplists:get_value(protocols, ConnectOpts) of
-                        undefined -> [];
-                        Protocols -> [{protocols, Protocols}]
-                    end,
-                    hackney_ssl:effective_opts(Host, SslOpts1, ConnectOpts);
-                _ ->
-                    %% Custom ssl_options keep the direct ssl_opts build (no
-                    %% session resumption); ssl_opts honors a user SNI as both
-                    %% the wire value and the verify target.
-                    MergedSslOpts = hackney_ssl:ssl_opts(Host, [{ssl_options, SslOpts0}]),
-                    AlpnOpts = hackney_ssl:alpn_opts(ConnectOpts),
-                    hackney_util:merge_opts(MergedSslOpts, AlpnOpts)
+            %% effective_opts is the single builder of ssl:connect options for
+            %% both default and custom ssl_options. It resolves SNI and ALPN
+            %% and adds TLS 1.3 resumption only for the default config (custom
+            %% ssl_options leave it off, see resumption_allowed/1).
+            SslOpts1 = case proplists:get_value(protocols, ConnectOpts) of
+                undefined -> SslOpts0;
+                Protocols -> [{protocols, Protocols} | SslOpts0]
             end,
+            FinalSslOpts = hackney_ssl:effective_opts(Host, SslOpts1, ConnectOpts),
             TransportOpts ++ [{ssl_options, FinalSslOpts}];
         _ -> TransportOpts
     end,

--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -2398,10 +2398,15 @@ h3_tls_opts(ConnectOpts, SslOpts) ->
         undefined -> Base;
         Family -> Base#{family => Family}
     end,
-    case proplists:get_value(session_ticket, ConnectOpts,
-           proplists:get_value(session_ticket, SslOpts, undefined)) of
+    Base2 = case proplists:get_value(session_ticket, ConnectOpts,
+              proplists:get_value(session_ticket, SslOpts, undefined)) of
         undefined -> Base1;
         Ticket -> Base1#{session_ticket => Ticket}
+    end,
+    %% Forward a user SNI so build_h3_opts can honor it (hostname or `disable').
+    case proplists:get_value(server_name_indication, SslOpts, undefined) of
+        undefined -> Base2;
+        Sni -> Base2#{server_name_indication => Sni}
     end.
 
 %% @private Use an explicitly configured CA as the H3 trust store. quic only
@@ -2469,11 +2474,9 @@ do_tcp_connect(From, Data) ->
                     end,
                     hackney_ssl:effective_opts(Host, SslOpts1, ConnectOpts);
                 _ ->
-                    %% Keep the legacy build for custom ssl_options: routing
-                    %% them through effective_opts would change the
-                    %% hostname-verification target for a user-supplied
-                    %% server_name_indication (merge_ssl_opts takes the first
-                    %% SNI occurrence).
+                    %% Custom ssl_options keep the direct ssl_opts build (no
+                    %% session resumption); ssl_opts honors a user SNI as both
+                    %% the wire value and the verify target.
                     MergedSslOpts = hackney_ssl:ssl_opts(Host, [{ssl_options, SslOpts0}]),
                     AlpnOpts = hackney_ssl:alpn_opts(ConnectOpts),
                     hackney_util:merge_opts(MergedSslOpts, AlpnOpts)

--- a/src/hackney_h3.erl
+++ b/src/hackney_h3.erl
@@ -936,7 +936,17 @@ build_h3_opts(Host, Opts) ->
                 false -> verify_none
             end
     end,
-    QuicOpts0 = #{server_name_indication => HostStr},
+    %% SNI: a user override wins (`disable' suppresses it); otherwise default
+    %% to the host, unless it is an IP literal (RFC 6066 forbids SNI for IPs).
+    QuicOpts0 = case maps:get(server_name_indication, Opts, undefined) of
+        undefined ->
+            case hackney_url:is_ip_literal(HostStr) of
+                true -> #{};
+                false -> #{server_name_indication => HostStr}
+            end;
+        disable -> #{};
+        Sni -> #{server_name_indication => Sni}
+    end,
     QuicOpts1 = case maps:get(cacerts, Opts, undefined) of
         undefined ->
             case maps:get(cacertfile, Opts, undefined) of

--- a/src/hackney_http_connect.erl
+++ b/src/hackney_http_connect.erl
@@ -18,6 +18,7 @@
   close/1,
   shutdown/2,
   sockname/1]).
+-export([proxy_ssl_opts/2]).
 
 -define(DEFAULT_RECV_TIMEOUT, infinity).
 
@@ -27,6 +28,20 @@
 %% Use hackney_ssl for SSL options (was hackney_connection)
 ssl_opts(Host, Opts) ->
   hackney_ssl:ssl_opts(Host, Opts).
+
+%% @doc TLS options for the proxy leg. Add SNI for the proxy host unless the
+%% user already set one or the proxy is addressed by IP literal (RFC 6066
+%% forbids SNI for IP literals).
+-spec proxy_ssl_opts(string() | binary(), list()) -> list().
+proxy_ssl_opts(ProxyHost, ProxySslOpts) ->
+  case lists:keymember(server_name_indication, 1, ProxySslOpts) of
+    true -> ProxySslOpts;
+    false ->
+      case hackney_url:is_ip_literal(ProxyHost) of
+        true -> ProxySslOpts;
+        false -> [{server_name_indication, ProxyHost} | ProxySslOpts]
+      end
+  end.
 
 %% @doc Atoms used to identify messages in {active, once | true} mode.
 messages({hackney_ssl, _}) ->
@@ -99,8 +114,7 @@ connect_to_proxy(ProxyHost, ProxyPort, ssl, ConnectOpts, Opts, Timeout) ->
   case hackney_happy:connect(ProxyHost, ProxyPort, ConnectOpts, Timeout) of
     {ok, TcpSocket} ->
       ProxySslOpts = proplists:get_value(proxy_ssl_options, Opts, []),
-      %% Add SNI for the proxy
-      SslOpts = [{server_name_indication, ProxyHost} | ProxySslOpts],
+      SslOpts = proxy_ssl_opts(ProxyHost, ProxySslOpts),
       %% GHSA-gp9c: forward the timeout to the proxy TLS handshake too.
       case ssl:connect(TcpSocket, SslOpts, Timeout) of
         {ok, SslSocket} ->

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -61,7 +61,11 @@ ssl_opts_1(Host, Options) ->
   end.
 
 merge_ssl_opts(Host, OverrideOpts, Options) ->
-  VerifyHost = case proplists:get_value(server_name_indication, OverrideOpts, disable) of
+  %% Verify against the chosen SNI: a user hostname wins, `disable' and no
+  %% SNI both verify against Host. effective_opts no longer prepends a
+  %% duplicate SNI, so the wire SNI and the verify target now agree.
+  VerifyHost = case proplists:get_value(server_name_indication, OverrideOpts) of
+    undefined -> Host;
     disable -> Host;
     SNI -> SNI
   end,
@@ -103,7 +107,17 @@ merge_ssl_opts(Host, OverrideOpts, Options) ->
 %% trust, so trust configs cannot cross by construction.
 -spec effective_opts(string(), list(), list()) -> list().
 effective_opts(Host, SslOpts, ConnectOpts) ->
-  SslOpts1 = [{server_name_indication, Host} | SslOpts],
+  %% Resolve SNI once: a user-supplied server_name_indication (a hostname or
+  %% `disable') wins; otherwise default to Host, unless Host is an IP literal
+  %% (RFC 6066 forbids SNI for IP literals), in which case emit none.
+  SslOpts1 = case lists:keymember(server_name_indication, 1, SslOpts) of
+    true -> SslOpts;
+    false ->
+      case hackney_url:is_ip_literal(Host) of
+        true -> SslOpts;
+        false -> [{server_name_indication, Host} | SslOpts]
+      end
+  end,
   Merged = ssl_opts(Host, [{ssl_options, SslOpts1}]),
   Alpn = case alpn_opts(SslOpts1) of
     [] -> alpn_opts(ConnectOpts);
@@ -213,7 +227,10 @@ options_key(FinalSslOpts) ->
 %% hashed as given, without reading the file. Deliberately excluded:
 %% `session_ticket' (injected per resumption, so the conn-side store key
 %% must not depend on it), and `family' and `happy_eyeballs' (connectivity
-%% options that do not affect trust).
+%% options that do not affect trust). A user-supplied
+%% `server_name_indication' is included so requests to one host:port with
+%% different SNI do not share a QUIC connection; the default SNI is the host
+%% itself, already part of the outer pool key.
 -spec h3_options_key(list(), list()) -> binary().
 h3_options_key(ConnectOpts, SslOpts) ->
   Insecure = proplists:get_value(insecure, ConnectOpts,
@@ -231,7 +248,8 @@ h3_options_key(ConnectOpts, SslOpts) ->
     CACerts ->
       {cacerts, CACerts}
   end,
-  crypto:hash(sha256, term_to_binary({VerifyMode, CaSource})).
+  Sni = proplists:get_value(server_name_indication, SslOpts, default),
+  crypto:hash(sha256, term_to_binary({VerifyMode, CaSource, Sni})).
 
 check_hostname_opts(Host0) ->
   Host1 = string:trim(Host0, trailing, "."),
@@ -290,7 +308,10 @@ check_hostname_opt(_Host, Opts) ->
 server_name_indication_opt(_Host, Opts) -> Opts.
 -else.
 server_name_indication_opt(Host, Opts) ->
-  [{server_name_indication, Host} | Opts].
+  case hackney_url:is_ip_literal(Host) of
+    true -> Opts;
+    false -> [{server_name_indication, Host} | Opts]
+  end.
 -endif.
 
 %% code from rebar3 undert BSD license

--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -25,6 +25,7 @@
          property/2]).
 
 -export([idnconvert_hostname/1]).
+-export([is_ip_literal/1]).
 
 -include("hackney_lib.hrl").
 
@@ -224,6 +225,22 @@ idnconvert_hostname(Host) ->
     false ->
       idna:utf8_to_ascii(Host)
   end.
+
+%% @doc True when Host is an IPv4/IPv6 literal. RFC 6066 forbids sending SNI
+%% for IP literals. Hosts reach the TLS layer bracket-stripped, but strip a
+%% stray bracket pair defensively.
+-spec is_ip_literal(binary() | string()) -> boolean().
+is_ip_literal(Host) when is_binary(Host) ->
+  is_ip_literal(binary_to_list(Host));
+is_ip_literal("[" ++ Rest) ->
+  is_ip_literal(string:trim(Rest, trailing, "]"));
+is_ip_literal(Host) when is_list(Host) ->
+  case inet:parse_address(Host) of
+    {ok, _} -> true;
+    {error, _} -> false
+  end;
+is_ip_literal(_) ->
+  false.
 
 unparse_url(#hackney_url{}=Url) ->
   #hackney_url{scheme = Scheme,

--- a/test/hackney_h3_zero_rtt_tests.erl
+++ b/test/hackney_h3_zero_rtt_tests.erl
@@ -21,7 +21,12 @@ build_opts_test_() ->
      {"no family leaves quic_opts without a family key", fun no_family/0},
      {"happy_eyeballs is forwarded into quic_opts", fun happy_eyeballs/0},
      {"session_ticket is forwarded into quic_opts", fun session_ticket/0},
-     {"family and session_ticket can be combined", fun family_and_ticket/0}
+     {"family and session_ticket can be combined", fun family_and_ticket/0},
+     {"hostname sets SNI", fun sni_hostname/0},
+     {"ipv4 host omits SNI", fun sni_ipv4/0},
+     {"ipv6 host omits SNI", fun sni_ipv6/0},
+     {"user SNI override wins", fun sni_override/0},
+     {"disable suppresses SNI", fun sni_disable/0}
     ].
 
 family_inet6() ->
@@ -58,6 +63,28 @@ family_and_ticket() ->
     ?assertEqual(inet6, maps:get(family, QuicOpts)),
     ?assertEqual(Ticket, maps:get(session_ticket, QuicOpts)).
 
+sni_hostname() ->
+    QuicOpts = maps:get(quic_opts, hackney_h3:build_h3_opts(<<"example.com">>, #{})),
+    ?assertEqual("example.com", maps:get(server_name_indication, QuicOpts)).
+
+sni_ipv4() ->
+    QuicOpts = maps:get(quic_opts, hackney_h3:build_h3_opts(<<"127.0.0.1">>, #{})),
+    ?assertNot(maps:is_key(server_name_indication, QuicOpts)).
+
+sni_ipv6() ->
+    QuicOpts = maps:get(quic_opts, hackney_h3:build_h3_opts(<<"::1">>, #{})),
+    ?assertNot(maps:is_key(server_name_indication, QuicOpts)).
+
+sni_override() ->
+    QuicOpts = maps:get(quic_opts, hackney_h3:build_h3_opts(
+                 <<"example.com">>, #{server_name_indication => "alt.example"})),
+    ?assertEqual("alt.example", maps:get(server_name_indication, QuicOpts)).
+
+sni_disable() ->
+    QuicOpts = maps:get(quic_opts, hackney_h3:build_h3_opts(
+                 <<"example.com">>, #{server_name_indication => disable})),
+    ?assertNot(maps:is_key(server_name_indication, QuicOpts)).
+
 %%====================================================================
 %% hackney_conn:h3_tls_opts/2 - family/session_ticket from either list
 %%====================================================================
@@ -68,7 +95,8 @@ tls_opts_test_() ->
      {"family from ssl_options", fun tls_family_ssl/0},
      {"session_ticket from connect_options", fun tls_ticket_connect/0},
      {"session_ticket from ssl_options", fun tls_ticket_ssl/0},
-     {"insecure maps to verify_none", fun tls_insecure/0}
+     {"insecure maps to verify_none", fun tls_insecure/0},
+     {"user SNI from ssl_options is forwarded", fun tls_sni_ssl/0}
     ].
 
 tls_family_connect() ->
@@ -92,6 +120,10 @@ tls_ticket_ssl() ->
 tls_insecure() ->
     M = hackney_conn:h3_tls_opts([{insecure, true}], []),
     ?assertEqual(verify_none, maps:get(verify, M)).
+
+tls_sni_ssl() ->
+    M = hackney_conn:h3_tls_opts([], [{server_name_indication, "alt.example"}]),
+    ?assertEqual("alt.example", maps:get(server_name_indication, M)).
 
 %%====================================================================
 %% hackney_pool - H3 session ticket cache

--- a/test/hackney_proxy_tests.erl
+++ b/test/hackney_proxy_tests.erl
@@ -1052,3 +1052,24 @@ has_auth_header(Data) ->
         nomatch -> false
     end.
 
+%%====================================================================
+%% Proxy-leg SNI selection
+%%====================================================================
+
+proxy_ssl_opts_hostname_test() ->
+    Opts = hackney_http_connect:proxy_ssl_opts("proxy.example", []),
+    ?assertEqual("proxy.example", proplists:get_value(server_name_indication, Opts)).
+
+proxy_ssl_opts_ipv4_test() ->
+    Opts = hackney_http_connect:proxy_ssl_opts("10.0.0.1", []),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts)).
+
+proxy_ssl_opts_ipv6_test() ->
+    Opts = hackney_http_connect:proxy_ssl_opts("::1", []),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts)).
+
+proxy_ssl_opts_user_sni_test() ->
+    Opts = hackney_http_connect:proxy_ssl_opts(
+             "proxy.example", [{server_name_indication, "set.by.user"}]),
+    ?assertEqual("set.by.user", proplists:get_value(server_name_indication, Opts)).
+

--- a/test/hackney_ssl_tests.erl
+++ b/test/hackney_ssl_tests.erl
@@ -220,6 +220,79 @@ h3_options_key_deterministic_across_processes_test() ->
     ?assertEqual(Key1, hackney_ssl:h3_options_key([], [{cacertfile, "/tmp/ca-a.pem"}])).
 
 %%====================================================================
+%% SNI Tests (Unit tests)
+%%====================================================================
+
+%% @private check_hostname target bound into the verify_fun init state.
+sni_verify_host(Opts) ->
+    case proplists:get_value(verify_fun, Opts) of
+        {_Fun, State} -> proplists:get_value(check_hostname, State);
+        _ -> undefined
+    end.
+
+effective_opts_sni_hostname_test() ->
+    Opts = hackney_ssl:effective_opts("example.com", [], []),
+    ?assertEqual("example.com", proplists:get_value(server_name_indication, Opts)),
+    ?assertEqual("example.com", sni_verify_host(Opts)).
+
+effective_opts_no_sni_for_ipv4_test() ->
+    Opts = hackney_ssl:effective_opts("127.0.0.1", [], []),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, Opts)),
+    ?assert(lists:keymember(cacerts, 1, Opts) orelse lists:keymember(cacertfile, 1, Opts)).
+
+effective_opts_no_sni_for_bare_ipv6_test() ->
+    Opts1 = hackney_ssl:effective_opts("::1", [], []),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts1)),
+    Opts2 = hackney_ssl:effective_opts("2001:db8::1", [], []),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts2)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, Opts2)).
+
+effective_opts_no_sni_for_bracketed_ipv6_test() ->
+    Opts = hackney_ssl:effective_opts("[::1]", [], []),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts)).
+
+effective_opts_user_sni_override_test() ->
+    %% A user SNI drives both the wire value and the verify target.
+    Opts = hackney_ssl:effective_opts(
+             "example.com", [{server_name_indication, "alt.example"}], []),
+    ?assertEqual("alt.example", proplists:get_value(server_name_indication, Opts)),
+    ?assertEqual("alt.example", sni_verify_host(Opts)).
+
+effective_opts_user_sni_disable_test() ->
+    Opts = hackney_ssl:effective_opts(
+             "example.com", [{server_name_indication, disable}], []),
+    %% `disable' means no wire SNI; verification stays bound to the host.
+    ?assertEqual(disable, proplists:get_value(server_name_indication, Opts)),
+    ?assertEqual("example.com", sni_verify_host(Opts)).
+
+merge_ssl_opts_verify_target_follows_user_sni_test() ->
+    %% Regression: the verify target must follow the user SNI, not the host.
+    Opts = hackney_ssl:ssl_opts(
+             "example.com", [{ssl_options, [{server_name_indication, "x.example"}]}]),
+    ?assertEqual("x.example", sni_verify_host(Opts)),
+    ?assertEqual("x.example", proplists:get_value(server_name_indication, Opts)).
+
+check_hostname_opts_no_sni_for_ip_test() ->
+    %% Suppressing SNI for an IP must not weaken verification.
+    Opts = hackney_ssl:check_hostname_opts("127.0.0.1"),
+    ?assertNot(proplists:is_defined(server_name_indication, Opts)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, Opts)),
+    ?assertEqual("127.0.0.1", sni_verify_host(Opts)).
+
+options_key_ip_differs_from_hostname_test() ->
+    KeyIp = hackney_ssl:options_key(hackney_ssl:effective_opts("127.0.0.1", [], [])),
+    KeyHost = hackney_ssl:options_key(hackney_ssl:effective_opts("example.com", [], [])),
+    ?assertNotEqual(KeyIp, KeyHost).
+
+h3_options_key_sni_override_differs_test() ->
+    Default = hackney_ssl:h3_options_key([], []),
+    OverrideX = hackney_ssl:h3_options_key([], [{server_name_indication, "x"}]),
+    OverrideY = hackney_ssl:h3_options_key([], [{server_name_indication, "y"}]),
+    ?assertNotEqual(Default, OverrideX),
+    ?assertNotEqual(OverrideX, OverrideY).
+
+%%====================================================================
 %% TLS 1.3 session resumption Tests (Unit tests)
 %%====================================================================
 


### PR DESCRIPTION
Three changes.

SNI handling is fixed across HTTP/1.1, HTTP/2 and HTTP/3, and on the HTTPS proxy leg. No server_name_indication is sent when the host (or HTTPS proxy) is an IP literal (RFC 6066 forbids it). A user-supplied server_name_indication is honored consistently as both the wire value and the hostname-verification target, on the HTTP/3 path and in proxy_ssl_options too, and disable suppresses SNI without weakening verification. Verification behavior for IP hosts is unchanged; only the illegal SNI is dropped.

The non-pooled custom-ssl direct connect now also builds its options through effective_opts, so one function builds the ssl:connect options for every path (verified option-equivalent to the previous build).

Also bumps quic to 1.6.5 and webtransport to 0.4.0.