### PR TITLE
Release 4.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,28 @@
 # NEWS
 
+4.4.0 - 2026-06-13
+------------------
+
+### Added
+
+- HTTP/2 streaming request bodies and streaming response reads. Passing
+  `stream` as the body now works over HTTP/2, as it already did for HTTP/1.1
+  and HTTP/3: send the request body in chunks with `send_body/2` then
+  `finish_send_body/1`, and read the response with `start_response/1` followed
+  by `body/1` or `stream_body/1`. (#875)
+- Full-duplex HTTP/2 bidirectional streaming (gRPC-style) via a new `h2_*`
+  API: `h2_open`, `h2_send`, `h2_recv`, `h2_send_trailers`, `h2_consume`,
+  `h2_setopts` and `h2_close`, mirroring the `ws_*` and `wt_*` APIs. A single
+  stream sends and receives interleaved, sends trailers, delivers messages in
+  passive or active mode, and applies receive backpressure with
+  `{flow_control, manual}` plus `h2_consume/2`. Backed by the new
+  `hackney_h2_stream` module. (#876)
+
+### Dependencies
+
+- h2 0.9.0 -> ~> 0.10.0. The requirement now accepts every patched 0.10
+  release without a further bump.
+
 4.3.0 - 2026-06-12
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An HTTP client for Erlang. Simple, reliable, fast.
 - **Async responses** - Get response chunks as messages. Process other work while waiting.
 - **WebSocket support** - Full WebSocket client with the same process-per-connection model.
 - **WebTransport support** - WebTransport client over HTTP/3 (or HTTP/2) with a WebSocket-shaped API; switch by swapping the `ws_` prefix for `wt_`.
+- **HTTP/2 bidirectional streams** - Full-duplex gRPC-style streaming with the `h2_*` API; send and receive interleaved on one stream, with trailers and flow control.
 - **IPv6 first** - Happy Eyeballs algorithm tries IPv6 before IPv4 for faster connections on modern networks.
 - **SSL by default** - Secure connections with certificate verification using Mozilla's CA bundle.
 - **Automatic decompression** - Transparently decompress gzip/deflate responses with `{auto_decompress, true}`.

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.3.0"},
+    {vsn, "4.4.0"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Cut 4.4.0 (minor). Since 4.3.0:

- HTTP/2 streaming request bodies and streaming response reads, reaching parity with HTTP/1.1 and HTTP/3 (#875).
- Full-duplex HTTP/2 bidirectional streaming via the new `h2_*` API, mirroring `ws_*` / `wt_*` (#876).
- h2 0.9.0 -> ~> 0.10.0.

Updates NEWS.md, the README feature list, and bumps vsn to 4.4.0.