### PR TITLE
Fix ex_doc warnings

### DIFF
--- a/guides/webtransport_guide.md
+++ b/guides/webtransport_guide.md
@@ -268,4 +268,3 @@ run(URL) ->
 - [WebSocket Guide](websocket_guide.md)
 - [HTTP/3 Guide](http3_guide.md)
 - [Getting Started](../GETTING_STARTED.md)
-```

--- a/src/hackney_ssl.erl
+++ b/src/hackney_ssl.erl
@@ -220,7 +220,7 @@ options_key(FinalSslOpts) ->
 
 %% @doc Hash the QUIC trust projection of an HTTP/3 connection into a pool
 %% key component. Includes exactly what decides server trust on the QUIC
-%% handshake, mirroring `hackney_conn:h3_tls_opts/2': the verify mode
+%% handshake, mirroring hackney_conn's h3_tls_opts/2: the verify mode
 %% derived from the `insecure' flag (read from ConnectOpts first, then
 %% SslOpts) and the CA source from SslOpts (the `cacerts' list, else the
 %% `cacertfile' path, else the default trust store). The cacertfile path is


### PR DESCRIPTION
Two doc-generation warnings surfaced when building the 4.4.0 docs:

- `hackney_ssl:h3_options_key/2` doc autolinked to `hackney_conn:h3_tls_opts/2`, a private helper, so ex_doc warned the reference was undefined/private. Reworded to plain text.
- `guides/webtransport_guide.md` had a stray trailing code fence after the Next Steps list, leaving an unclosed block. Removed it.

`rebar3 ex_doc` now runs clean.