### PR TITLE
Use patch-relative version ranges for first-party deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,11 +53,11 @@
 
 {deps, [
         %% Pure Erlang QUIC + HTTP/3 stack
-        {quic, "1.6.5"},
+        {quic, "~>1.6.5"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "~>0.10.0"},
+        {h2, "~>0.10.1"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
-        {webtransport, "0.4.0"},
+        {webtransport, "~>0.4.1"},
         {idna, "~>7.1.0"},
         {mimerl, "~>1.4"},
         {certifi, "~>2.17.0"},


### PR DESCRIPTION
Fixes #879.

The exact pin `webtransport "0.4.0"` requires `h2` exactly `0.9.0`, which contradicts hackney's own `h2 ~> 0.10.0` and makes strict resolvers (mix) refuse to install 4.4.0.

Switch quic, h2 and webtransport to `~>` patch ranges so the 0.4.x / 0.10.x / 1.6.x lines resolve while the next minor still needs an explicit bump:

- `quic` `1.6.5` -> `~>1.6.5`
- `h2` `~>0.10.0` -> `~>0.10.1`
- `webtransport` `0.4.0` -> `~>0.4.1`

`~>0.4.1` pulls in webtransport 0.4.1, which already relaxed its own h2 requirement to `~> 0.10.1`, removing the conflict. Clean `rebar3 compile` resolves webtransport 0.4.1 / h2 0.10.1 / quic 1.6.5.