### PR TITLE
Apply pool overflow to the ssl_pooling checkout path

### DIFF
--- a/src/hackney_pool.erl
+++ b/src/hackney_pool.erl
@@ -946,11 +946,13 @@ checkout_ssl_fallback(SslKey, Requester, Opts, State) ->
                     start_ssl_checkout_conn(SslKey, Requester, Opts,
                                             State#state{available=Available2})
             end;
-        none when TotalInUse >= MaxConn ->
-            ?report_trace("pool: at max connections", [{pool, PoolName}, {in_use, TotalInUse}]),
-            {reply, {error, checkout_timeout}, State};
         none ->
-            ?report_trace("pool: starting new connection", [{pool, PoolName}]),
+            %% No pooled TCP connection. Per-host concurrency is already capped
+            %% by hackney_load_regulation, so start one even at max_connections:
+            %% it is an overflow connection, closed at checkin (see do_checkin)
+            %% rather than pooled. Mirrors the plain checkout path.
+            ?report_trace("pool: starting new connection",
+                          [{pool, PoolName}, {overflow, TotalInUse >= MaxConn}]),
             start_ssl_checkout_conn(SslKey, Requester, Opts, State)
     end.
 

--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -63,6 +63,8 @@ hackney_pool_integration_test_() ->
        {timeout, 30, fun test_checkout_survives_dying_connection/0}},
       {"checkout_ssl without pooled conns returns needs_upgrade",
        fun test_checkout_ssl_needs_upgrade/0},
+      {"checkout_ssl overflows past pool_size instead of timing out",
+       fun test_checkout_ssl_overflow/0},
       {"checkin of an SSL-keyed conn that was never upgraded closes it",
        fun test_checkout_ssl_unupgraded_closes/0},
       {"checkin pools an upgraded HTTPS/1.1 conn under its SSL key",
@@ -523,6 +525,27 @@ test_checkout_ssl_needs_upgrade() ->
     ?assertEqual(1, proplists:get_value(in_use_count, Stats)),
     hackney_conn:stop(Pid),
     ok = hackney_pool:stop_pool(test_pool_ssl_co).
+
+test_checkout_ssl_overflow() ->
+    %% pool_size bounds the warm pool, not concurrency. With pool_size=1 a
+    %% second concurrent SSL checkout opens an overflow connection instead of
+    %% failing with checkout_timeout.
+    ok = hackney_pool:start_pool(test_pool_ssl_overflow,
+                                 [{pool_size, 1}, {prewarm_count, 0}]),
+    TlsKey = crypto:hash(sha256, <<"ssl-overflow">>),
+    Opts = [{pool, test_pool_ssl_overflow}, {tls_key, TlsKey}],
+    {ok, _, Pid1, needs_upgrade} =
+        hackney_pool:checkout_ssl("127.0.0.1", ?PORT, hackney_ssl, Opts),
+    {ok, _, Pid2, needs_upgrade} =
+        hackney_pool:checkout_ssl("127.0.0.1", ?PORT, hackney_ssl, Opts),
+    ?assert(is_process_alive(Pid1)),
+    ?assert(is_process_alive(Pid2)),
+    ?assertNotEqual(Pid1, Pid2),
+    Stats = hackney_pool:get_stats(test_pool_ssl_overflow),
+    ?assertEqual(2, proplists:get_value(in_use_count, Stats)),
+    hackney_conn:stop(Pid1),
+    hackney_conn:stop(Pid2),
+    ok = hackney_pool:stop_pool(test_pool_ssl_overflow).
 
 test_checkout_ssl_unupgraded_closes() ->
     %% Anomaly guard: an SSL-keyed conn checked in without being upgraded


### PR DESCRIPTION
Follow-up to 4.4.1. The overflow fix landed on the plain TCP checkout (and so on default HTTPS, which checks out a TCP conn then upgrades), but `checkout_ssl_fallback` - the opt-in `ssl_pooling` path - still had the old fast-fail:

```erlang
none when TotalInUse >= MaxConn -> {reply, {error, checkout_timeout}, State};
```

So `ssl_pooling` with pool_size < max_per_host could still hit the spurious checkout_timeout race. This makes it open an overflow connection like the plain path; per-host concurrency stays capped by max_per_host, and the checkin side already applies the idle-pool cap via pool_has_idle_room/1.

HTTP/2 and HTTP/3 are unaffected: they multiplex over shared connections and have no per-checkout max_connections slot.

Adds test_checkout_ssl_overflow (two SSL checkouts at pool_size=1 both succeed with distinct live conns, in_use=2).