### PR TITLE
Release 4.4.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+4.4.2 - 2026-06-16
+------------------
+
+### Fixed
+
+- Apply the pool overflow fix to the opt-in `ssl_pooling` checkout path. With
+  `ssl_pooling` enabled and `pool_size` below `max_per_host`, a second
+  concurrent HTTPS request could still fail with `checkout_timeout`; it now
+  opens an overflow connection like the plain checkout path, closed at checkin
+  rather than pooled. HTTP/2 and HTTP/3 are unaffected (they multiplex over
+  shared connections).
+
 4.4.1 - 2026-06-16
 ------------------
 

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.4.1"},
+    {vsn, "4.4.2"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Patch release. Applies the 4.4.1 pool overflow fix to the opt-in ssl_pooling checkout path (checkout_ssl_fallback), which still fast-failed with checkout_timeout at max_connections. It now opens an overflow connection like the plain checkout path; checkin already applies the idle-pool cap. HTTP/2 and HTTP/3 are unaffected (multiplexed). (#882)