### PR TITLE
Release 4.4.4

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.4.3"},
+    {vsn, "4.4.4"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Patch release. Changelog already on master (NEWS 4.4.4).

### Fixed
- HTTP/2: retire a connection after GOAWAY (no reuse of a recycled conn); cancel the stalled stream when the recv_timeout watchdog fires.
- HTTP/1.1: buffer and consume bytes stranded by #544 `{active, once}` on a reused connection instead of dropping it, bounded; server close still refuses reuse (#544).