### PR TITLE
Release 4.4.5

### DIFF
--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.4.4"},
+    {vsn, "4.4.5"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Release 4.4.5. Bumps `vsn` to 4.4.5 in `src/hackney.app.src`; NEWS.md 4.4.5 entry already on master.

Covers the changes merged since 4.4.4:

- HTTPS: resumed TLS 1.3 sessions no longer mislabel an HTTP/2 connection as HTTP/1 (#889).
- HTTP/1.1: `recv_status` fails fast on a non-HTTP/1 status line instead of spinning (#889).
- Connection pooling: `Connection: close` not pooled on the sync path; checkin gated on keep-alive + socket-ready; closed pool entries discarded, not reanimated (#888).