### PR TITLE
Deflake eunit: gate live HTTP/3 tests, harden checkout-timeout test

### DIFF
--- a/test/hackney_conn_http3_tests.erl
+++ b/test/hackney_conn_http3_tests.erl
@@ -29,8 +29,20 @@ cleanup(_) ->
 %% HTTP/3 Connection Tests
 %%====================================================================
 
+%% Live external-server tests (cloudflare over HTTP/3) are opt-in: they depend on
+%% the network and intermittently crash the quic h3 library, which destabilizes
+%% CI. Set HACKNEY_LIVE_TESTS to run them; the HTTP/3 e2e CT suites
+%% (make http3-e2e-test) cover live testing otherwise. parse_headers_test_ below
+%% is a pure unit test and stays enabled.
+maybe_live(GenFun) ->
+    case os:getenv("HACKNEY_LIVE_TESTS") of
+        false -> [];
+        _ -> GenFun()
+    end.
+
 %% Test HTTP/3 connection via hackney_conn
-http3_conn_test_() ->
+http3_conn_test_() -> maybe_live(fun http3_conn_live/0).
+http3_conn_live() ->
     {
         "HTTP/3 connection tests via hackney_conn",
         {

--- a/test/hackney_h3_integration_tests.erl
+++ b/test/hackney_h3_integration_tests.erl
@@ -139,7 +139,18 @@ get_location(Headers) ->
 %% TLS Verification Tests
 %%====================================================================
 
-tls_test_() ->
+%% Live external-server tests (cloudflare/httpbin over HTTP/3) are opt-in: they
+%% depend on the network and intermittently crash the quic h3 library, which
+%% destabilizes CI. Set HACKNEY_LIVE_TESTS to run them; the HTTP/3 e2e CT suites
+%% (make http3-e2e-test) cover live testing otherwise.
+maybe_live(GenFun) ->
+    case os:getenv("HACKNEY_LIVE_TESTS") of
+        false -> [];
+        _ -> GenFun()
+    end.
+
+tls_test_() -> maybe_live(fun tls_live/0).
+tls_live() ->
     {
         "HTTP/3 TLS verification tests",
         {
@@ -186,7 +197,8 @@ test_connect_with_verify() ->
 %% Redirect Tests
 %%====================================================================
 
-redirect_test_() ->
+redirect_test_() -> maybe_live(fun redirect_live/0).
+redirect_live() ->
     {
         "HTTP/3 redirect handling tests",
         {
@@ -252,7 +264,8 @@ test_redirect_path() ->
 %% HTTP Methods Tests
 %%====================================================================
 
-methods_test_() ->
+methods_test_() -> maybe_live(fun methods_live/0).
+methods_live() ->
     {
         "HTTP/3 method tests",
         {
@@ -344,7 +357,8 @@ test_multiple_requests() ->
 %% High-level API Tests
 %%====================================================================
 
-high_level_api_test_() ->
+high_level_api_test_() -> maybe_live(fun high_level_api_live/0).
+high_level_api_live() ->
     {
         "HTTP/3 high-level API tests",
         {
@@ -391,7 +405,8 @@ test_h3_connect_api() ->
 %% Error Handling Tests
 %%====================================================================
 
-error_handling_test_() ->
+error_handling_test_() -> maybe_live(fun error_handling_live/0).
+error_handling_live() ->
     {
         "HTTP/3 error handling tests",
         {

--- a/test/hackney_http3_integration_tests.erl
+++ b/test/hackney_http3_integration_tests.erl
@@ -31,7 +31,18 @@ cleanup(_) ->
 %% HTTP/3 Integration Tests
 %%====================================================================
 
-http3_integration_test_() ->
+%% Live external-server tests (cloudflare/httpbin over HTTP/3) are opt-in: they
+%% depend on the network and intermittently crash the quic h3 library, which
+%% destabilizes CI. Set HACKNEY_LIVE_TESTS to run them; the HTTP/3 e2e CT suites
+%% (make http3-e2e-test) cover live testing otherwise.
+maybe_live(GenFun) ->
+    case os:getenv("HACKNEY_LIVE_TESTS") of
+        false -> [];
+        _ -> GenFun()
+    end.
+
+http3_integration_test_() -> maybe_live(fun http3_integration_live/0).
+http3_integration_live() ->
     {
         "HTTP/3 hackney API integration tests",
         {
@@ -109,7 +120,8 @@ test_altsvc_enables_h3() ->
 %% Protocol Selection Tests
 %%====================================================================
 
-protocol_selection_test_() ->
+protocol_selection_test_() -> maybe_live(fun protocol_selection_live/0).
+protocol_selection_live() ->
     {
         "Protocol selection tests",
         {
@@ -158,7 +170,8 @@ test_blocked_fallback() ->
 %% hackney:get with HTTP/3 Tests
 %%====================================================================
 
-http3_get_test_() ->
+http3_get_test_() -> maybe_live(fun http3_get_live/0).
+http3_get_live() ->
     {
         "HTTP/3 hackney:get tests",
         {

--- a/test/hackney_http3_streaming_tests.erl
+++ b/test/hackney_http3_streaming_tests.erl
@@ -31,7 +31,18 @@ cleanup(_) ->
 %% HTTP/3 Async Streaming Tests
 %%====================================================================
 
-h3_async_streaming_test_() ->
+%% Live external-server tests (cloudflare over HTTP/3) are opt-in: they depend on
+%% the network and intermittently crash the quic h3 library, which destabilizes
+%% CI. Set HACKNEY_LIVE_TESTS to run them; the HTTP/3 e2e CT suites
+%% (make http3-e2e-test) cover live testing otherwise.
+maybe_live(GenFun) ->
+    case os:getenv("HACKNEY_LIVE_TESTS") of
+        false -> [];
+        _ -> GenFun()
+    end.
+
+h3_async_streaming_test_() -> maybe_live(fun h3_async_streaming_live/0).
+h3_async_streaming_live() ->
     {
         "HTTP/3 async streaming tests",
         {
@@ -50,7 +61,8 @@ h3_async_streaming_test_() ->
 %% HTTP/3 Pull-based Streaming Tests (stream_body)
 %%====================================================================
 
-h3_stream_body_test_() ->
+h3_stream_body_test_() -> maybe_live(fun h3_stream_body_live/0).
+h3_stream_body_live() ->
     {
         "HTTP/3 stream_body tests",
         {
@@ -137,7 +149,8 @@ read_all_chunks(ConnPid, Acc) ->
 %% HTTP/3 Body Sending Tests (streaming uploads)
 %%====================================================================
 
-h3_send_body_test_() ->
+h3_send_body_test_() -> maybe_live(fun h3_send_body_live/0).
+h3_send_body_live() ->
     {
         "HTTP/3 send_body tests",
         {

--- a/test/hackney_pool_tests.erl
+++ b/test/hackney_pool_tests.erl
@@ -773,10 +773,17 @@ test_checkout_timeout() ->
     URL = <<"http://localhost:8123/pool">>,
     Headers = [],
     hackney_pool:start_pool(pool_test_timeout, [{pool_size, 1}]),
-    Opts = [{max_body, 2048}, {pool, pool_test_timeout}, {max_per_host, 1},
-            {connect_timeout, 1000}, {checkout_timeout, 100}],
-    {ok, Ref} = hackney:request(post, URL, Headers, stream, Opts),
-    {error, Error} = hackney:request(post, URL, Headers, stream, Opts),
+    BaseOpts = [{max_body, 2048}, {pool, pool_test_timeout}, {max_per_host, 1},
+                {connect_timeout, 1000}],
+    %% The first request must acquire the single per-host slot; give it a
+    %% generous checkout_timeout so it is not itself raced by a slow connect or
+    %% transient load-regulation contention on the shared localhost:8123 host
+    %% (only the second request, which must wait for that slot, uses the tight
+    %% timeout we are actually asserting on).
+    {ok, Ref} = hackney:request(post, URL, Headers, stream,
+                                [{checkout_timeout, 5000} | BaseOpts]),
+    {error, Error} = hackney:request(post, URL, Headers, stream,
+                                     [{checkout_timeout, 100} | BaseOpts]),
     hackney:close(Ref),
     ?assertEqual(checkout_timeout, Error),
     hackney_pool:stop_pool(pool_test_timeout).


### PR DESCRIPTION
The default `rebar3 eunit` run is flaky on Linux x86_64 CI: the live-cloudflare HTTP/3 eunit tests intermittently crash the quic h3 library (`quic_h3_connection` gen_statem), and the resulting load makes the tight-timeout `test_checkout_timeout` race and fail. Neither is a product regression.

- Gate the live HTTP/3 eunit tests (connect to cloudflare/httpbin) behind an opt-in `HACKNEY_LIVE_TESTS` env via a per-module `maybe_live/1`; the default run skips them. The HTTP/3 e2e CT suites (`make http3-e2e-test`) still cover live testing. The pure-unit `parse_headers_test_` stays enabled.
- Harden `test_checkout_timeout`: its first request now uses a generous `checkout_timeout` so it reliably acquires the single per-host slot under load; only the second request (which must time out) keeps the tight 100ms timeout.

Local `rebar3 eunit` (flag unset): all 973 tests pass, no h3 crash reports.