### PR TITLE
Release 4.5.1: bump h2 to 0.10.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+4.5.1 - 2026-07-04
+------------------
+
+### Changed
+
+- Bump `h2` to 0.10.3. It fixes an HTTP/2 upload hang: a sender blocked on
+  flow control is now released with `{error, stream_reset}` or
+  `{error, stream_closed}` when the peer cancels the stream, instead of
+  hanging for the connection's lifetime. This affects hackney's streamed
+  request bodies over HTTP/2 when the server resets the stream
+  mid-backpressure.
+
 4.5.0 - 2026-07-04
 ------------------
 

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
         %% Pure Erlang QUIC + HTTP/3 stack
         {quic, "~>1.6.5"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "~>0.10.1"},
+        {h2, "~>0.10.3"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
         {webtransport, "~>0.4.1"},
         {idna, "~>7.1.0"},

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.5.0"},
+    {vsn, "4.5.1"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Patch release bumping h2 to ~>0.10.3. The new h2 fixes an HTTP/2 upload hang: a sender blocked on flow control is now released with `{error, stream_reset}` or `{error, stream_closed}` when the peer cancels the stream, instead of hanging for the connection's lifetime. Version bumped to 4.5.1 and NEWS.md updated.