### PR TITLE
Bump h2 to 0.10.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+4.5.2 - 2026-07-05
+------------------
+
+### Changed
+
+- Bump `h2` to 0.10.4. It fixes a regression from 0.10.3 where a blocking
+  send whose data had fully drained received `{error, stream_closed}` when
+  the stream closed on its END_STREAM chunk. A waiting sender is now settled
+  as `ok` once the send buffer has drained, and only gets the close-reason
+  error when data is still outstanding.
+
 4.5.1 - 2026-07-04
 ------------------
 

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
         %% Pure Erlang QUIC + HTTP/3 stack
         {quic, "~>1.6.5"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "~>0.10.3"},
+        {h2, "~>0.10.4"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
         {webtransport, "~>0.4.1"},
         {idna, "~>7.1.0"},


### PR DESCRIPTION
Bumps the `h2` dependency to 0.10.4, which fixes a regression from 0.10.3: a blocking send whose data had fully drained received `{error, stream_closed}` when the stream closed on its END_STREAM chunk. A waiting sender is now settled as `ok` once the send buffer has drained, and only gets the close-reason error when data is still outstanding.

NEWS updated with a 4.5.2 entry. No release yet.