### PR TITLE
Bump webtransport to 0.4.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
   SETTINGS frame now closes the connection cleanly instead of crashing; and
   a client recognizes a server stateless reset (RFC 9000 §10.3) and closes
   promptly instead of waiting for the idle timeout.
+- Bump `webtransport` to 0.4.3, which aligns its transitive `h2` (0.10.4) and
+  `quic` (1.7.0) dependencies with hackney's own, so the `wt_*` API runs on
+  the same HTTP/2 and HTTP/3 stack versions.
 
 4.5.1 - 2026-07-04
 ------------------

--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,7 @@
         %% Pure Erlang HTTP/2 stack
         {h2, "~>0.10.4"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
-        {webtransport, "~>0.4.1"},
+        {webtransport, "~>0.4.3"},
         {idna, "~>7.1.0"},
         {mimerl, "~>1.4"},
         {certifi, "~>2.17.0"},


### PR DESCRIPTION
Bumps the `webtransport` dependency to 0.4.3, which aligns its transitive `h2` (0.10.4) and `quic` (1.7.0) dependencies with hackney's own, so the `wt_*` API runs on the same HTTP/2 and HTTP/3 stack versions.

Folded into the pending 4.5.2 NEWS entry.