### PR TITLE
Overload connect function to accept binary host

### DIFF
--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -109,11 +109,10 @@ connect(URL, Options) when is_binary(URL) orelse is_list(URL) ->
 connect(Transport, Host, Port) ->
   connect(Transport, Host, Port, []).
 
--spec connect(module(), binary(), inet:port_number(), list()) -> {ok, conn()} | {error, term()}.
+-spec connect(module(), string() | binary(), inet:port_number(), list()) ->
+        {ok, conn()} | {error, term()}.
 connect(Transport, Host, Port, Options) when is_binary(Host) ->
-  connect(Transport, binary_to_list(Host), Port, Options).
-
--spec connect(module(), string(), inet:port_number(), list()) -> {ok, conn()} | {error, term()}.
+  connect(Transport, binary_to_list(Host), Port, Options);
 connect(Transport, Host, Port, Options) ->
   %% Check if using a pool
   UsePool = use_pool(Options),

--- a/src/hackney.erl
+++ b/src/hackney.erl
@@ -109,6 +109,10 @@ connect(URL, Options) when is_binary(URL) orelse is_list(URL) ->
 connect(Transport, Host, Port) ->
   connect(Transport, Host, Port, []).
 
+-spec connect(module(), binary(), inet:port_number(), list()) -> {ok, conn()} | {error, term()}.
+connect(Transport, Host, Port, Options) when is_binary(Host) ->
+  connect(Transport, binary_to_list(Host), Port, Options).
+
 -spec connect(module(), string(), inet:port_number(), list()) -> {ok, conn()} | {error, term()}.
 connect(Transport, Host, Port, Options) ->
   %% Check if using a pool


### PR DESCRIPTION
This was present in 1.* versions: https://github.com/benoitc/hackney/blob/1.25.0/src/hackney_connect.erl#L29-L30

It breaks some of our dependencies, so I added it back in the main hackney.erl