### PR TITLE
Bump h2 to 0.11.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # NEWS
 
+4.6.1 - 2026-07-15
+------------------
+
+### Changed
+
+- Bump `h2` to 0.11.0. It adds `h2:peername/1`, which returns the peer's
+  `{IpAddress, Port}` for a live connection. Additive only; no behavior
+  change for hackney.
+
 4.6.0 - 2026-07-15
 ------------------
 

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
         %% Pure Erlang QUIC + HTTP/3 stack
         {quic, "~>1.7.0"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "~>0.10.4"},
+        {h2, "~>0.11.0"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
         {webtransport, "~>0.4.3"},
         {idna, "~>7.1.0"},

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.6.0"},
+    {vsn, "4.6.1"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Bumps the h2 dependency to 0.11.0, which adds `h2:peername/1` returning the peer's `{IpAddress, Port}` for a live connection. Additive only; no behavior change for hackney.