### PR TITLE
Bump quic to 1.7.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+unreleased
+----------
+
+### Changed
+
+- Bump `quic` to 1.7.1. A clean QUIC connection close (idle pooled HTTP/3
+  connections, orderly shutdown) no longer emits ERROR and CRASH reports from
+  `quic_h3_connection` nor propagates an abnormal exit to the connection
+  owner. This also removes the intermittent eunit group cancellation in the
+  h3/wt test suites.
+
 4.7.1 - 2026-07-17
 ------------------
 

--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
 
 {deps, [
         %% Pure Erlang QUIC + HTTP/3 stack
-        {quic, "~>1.7.0"},
+        {quic, "~>1.7.1"},
         %% Pure Erlang HTTP/2 stack
         {h2, "~>0.11.0"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API


### PR DESCRIPTION
Picks up the quic 1.7.1 fix: a clean QUIC connection close (idle pooled HTTP/3 connections, orderly shutdown) no longer stops `quic_h3_connection` with the abnormal `quic_closed` reason, so no more ERROR/CRASH reports on teardown and no abnormal exit propagated to the connection owner.

Verified here: 10 consecutive runs of the h3/wt suites with zero failures and zero group cancellations (previously ~1/8 cancelled), a wt run emits no crash reports (previously several per run), and a live HTTP/3 request followed by an idle close stays silent.