### PR TITLE
Always add Content-Length: 0 even for empty bodies

### DIFF
--- a/src/hackney_conn.erl
+++ b/src/hackney_conn.erl
@@ -2123,8 +2123,12 @@ build_headers(_Method, Headers0, Body, Netloc) ->
 
     %% Add Content-Length for bodies
     case Body of
-        <<>> -> Headers3;
-        [] -> Headers3;
+        B when B =:= <<>> orelse B =:= [] ->
+            case hackney_headers:is_key(<<"content-length">>, Headers3) of
+                true -> Headers3;
+                false ->
+                    hackney_headers:store(<<"Content-Length">>, 0, Headers3)
+            end;
         _ when is_binary(Body) ->
             Len = byte_size(Body),
             case hackney_headers:is_key(<<"content-length">>, Headers3) of


### PR DESCRIPTION
I got a report on https://github.com/aws-beam/aws-elixir/issues/238 that the upgrade I recently did to a later version of Hackney broke things for 0-sized bodies. AWS apparently requires a Content-Length being set even for 0-sized bodies.

Instead of implementing a fix on my end, I'm testing the waters to see how open you are to fixing this from within Hackney itself. 