### PR TITLE
Release 4.7.3

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         otp: ["27.2", "28.0", "29.0"]
-        rebar3: ['3.25.0']
+        rebar3: ['3.27.0']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: erlef/setup-beam@v1
@@ -50,9 +50,9 @@ jobs:
     strategy:
       matrix:
         otp: ["27.2"]
-        rebar3: ['3.25.0']
+        rebar3: ['3.27.0']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: erlef/setup-beam@v1
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         otp: ["27"]
-        rebar3: ['3.25.0']
+        rebar3: ['3.27.0']
     steps:
       - name: Install Erlang and Go
         env:
@@ -86,7 +86,7 @@ jobs:
         run: |
           wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3 }}/rebar3 && chmod +x rebar3
           sudo mv rebar3 /usr/local/bin/ && sudo chmod +x /usr/local/bin/rebar3
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - run: make test
@@ -96,7 +96,7 @@ jobs:
     name: FreeBSD 14.2 OTP-28
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Test on FreeBSD

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,26 @@
 # NEWS
 
-unreleased
-----------
+4.7.3 - 2026-08-11
+------------------
 
 ### Fixed
 
+- Reusing a pooled HTTP/2 or HTTP/3 connection no longer crashes the caller of
+  `hackney:connect/4` when the pooled connection terminates during the checkout
+  liveness probe. The `get_state` probe is guarded so a terminating connection
+  falls through to a fresh one (#914).
+- `hackney_url:normalize/2` now rejects a host that reaches an IP literal only
+  after IDNA folds the Unicode full-stop variants (U+3002/U+FF0E/U+FF61) to
+  ASCII dots (for example `127。0。0。1` becoming `127.0.0.1`), closing a bypass
+  of the percent-encoded-IP check.
+- The CONNECT proxy handshake rejects CR/LF/NUL in the target host instead of
+  concatenating it into the request line and `Host` header.
+- The pooled HTTPS upgrade bounds the TLS handshake with `connect_timeout`
+  (`ssl:connect/3`), so a server that stalls the handshake no longer pins the
+  connection process and its pool slot (#916).
+- The streaming request path sanitizes header values (CR/LF) like the buffered
+  path, and the request method is validated (CR/LF/NUL) at every entry point,
+  not just the request target.
 - A response body cut short by the peer closing mid-transfer no longer leaks
   the connection process. `read_full_body/2` hands back `socket = undefined`,
   so the connection went straight to `closed` and never reached the reuse
@@ -18,6 +34,13 @@ unreleased
 - `hackney_conn:get_location/1` and `set_location/2` no longer exit with
   `noproc` when the connection has already stopped, which would otherwise
   propagate out of `hackney:request/5` on the redirect path.
+
+### Changed
+
+- Like curl, an empty body on a body-bearing method (POST/PUT/PATCH) now sends
+  `Content-Length: 0`; bodyless methods (GET/HEAD/DELETE) are unchanged (#917).
+- Update dependencies to their latest releases: `quic` 1.8.0, `webtransport`
+  0.4.4, `mimerl` 1.5.0, and `cowboy` 2.18.0 for the test suite.
 
 4.7.2 - 2026-07-17
 ------------------

--- a/rebar.config
+++ b/rebar.config
@@ -53,20 +53,20 @@
 
 {deps, [
         %% Pure Erlang QUIC + HTTP/3 stack
-        {quic, "~>1.7.1"},
+        {quic, "~>1.8.0"},
         %% Pure Erlang HTTP/2 stack
         {h2, "~>0.11.0"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
-        {webtransport, "~>0.4.3"},
+        {webtransport, "~>0.4.4"},
         {idna, "~>7.1.0"},
-        {mimerl, "~>1.4"},
+        {mimerl, "~>1.5"},
         {certifi, "~>2.17.0"},
         {parse_trans, "3.4.2"},
         {ssl_verify_fun, "~>1.1.0"}
        ]}.
 
 {profiles, [{test, [
-               {deps, [{cowboy, "2.16.0"}, {jsx, "3.1.0"}]},
+               {deps, [{cowboy, "2.18.0"}, {jsx, "3.1.0"}]},
                %% rebar3 can't parse cowboy 2.13+ Elixir-style ">= X and < Y"
                %% reqs for cowlib/ranch; override with bare names so rebar3
                %% resolves them itself (rebar3#2364).

--- a/src/hackney.app.src
+++ b/src/hackney.app.src
@@ -4,7 +4,7 @@
 {application, hackney,
   [
     {description, "Simple HTTP client with HTTP/1.1, HTTP/2, and HTTP/3 support"},
-    {vsn, "4.7.2"},
+    {vsn, "4.7.3"},
     {registered, [hackney_pool]},
     {applications, [kernel,
       stdlib,


### PR DESCRIPTION
Bundles everything merged since 4.7.2 and refreshes dependencies.

### Fixed
- Pooled H2/H3 checkout get_state probe guard (#914/#915)
- normalize/2 rejects IDNA dot-variant hosts that fold to IP literals (#920)
- CONNECT proxy rejects CR/LF/NUL in the target host (#921)
- Pooled TLS upgrade bounded by connect_timeout (#922)
- Streaming request header sanitize + method validation (#924)
- Dead-end unpooled connections stop instead of leaking; get/set_location noproc-safe (#918/#919)

### Changed
- curl-style Content-Length: 0 for empty POST/PUT/PATCH bodies (#917/#925)
- Dependencies: quic 1.8.0, webtransport 0.4.4, mimerl 1.5.0, cowboy 2.18.0 (test)

Version bumped to 4.7.3 in NEWS.md and hackney.app.src.