### PR TITLE
Bump h2 to 0.12.0 and webtransport to 0.4.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -55,9 +55,9 @@
         %% Pure Erlang QUIC + HTTP/3 stack
         {quic, "~>1.8.0"},
         %% Pure Erlang HTTP/2 stack
-        {h2, "~>0.11.0"},
+        {h2, "~>0.12.0"},
         %% WebTransport client (HTTP/3 and HTTP/2) - powers the wt_* API
-        {webtransport, "~>0.4.4"},
+        {webtransport, "~>0.4.5"},
         {idna, "~>7.1.0"},
         {mimerl, "~>1.5"},
         {certifi, "~>2.17.0"},


### PR DESCRIPTION
h2 0.12.0 adds `serve_socket/2` and runs the TLS handshake in the per-connection process instead of the acceptor. Both changes are server side, so the client is not affected.

webtransport 0.4.5 is a patch release.

eunit is green (1096 tests), xref and dialyzer are clean.